### PR TITLE
Allow users to adjust volume of break sample

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Configuration/SentakkiRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Sentakki/Configuration/SentakkiRulesetConfigManager.cs
@@ -24,6 +24,9 @@ namespace osu.Game.Rulesets.Sentakki.Configuration
             SetDefault(SentakkiRulesetSettings.LaneInputMode, LaneInputMode.Button);
             SetDefault(SentakkiRulesetSettings.SnakingSlideBody, true);
             SetDefault(SentakkiRulesetSettings.DetailedJudgements, false);
+
+            SetDefault(SentakkiRulesetSettings.BreakOverrideVolumeToggle, false);
+            SetDefault(SentakkiRulesetSettings.BreakOverrideVolumeValue, 0.5, 0, 1, 0.01f);
         }
     }
 
@@ -51,6 +54,8 @@ namespace osu.Game.Rulesets.Sentakki.Configuration
         TouchAnimationDuration,
         LaneInputMode,
         SnakingSlideBody,
-        DetailedJudgements
+        DetailedJudgements,
+        BreakOverrideVolumeToggle,
+        BreakOverrideVolumeValue
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Configuration/SentakkiRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Sentakki/Configuration/SentakkiRulesetConfigManager.cs
@@ -24,9 +24,7 @@ namespace osu.Game.Rulesets.Sentakki.Configuration
             SetDefault(SentakkiRulesetSettings.LaneInputMode, LaneInputMode.Button);
             SetDefault(SentakkiRulesetSettings.SnakingSlideBody, true);
             SetDefault(SentakkiRulesetSettings.DetailedJudgements, false);
-
-            SetDefault(SentakkiRulesetSettings.BreakOverrideVolumeToggle, false);
-            SetDefault(SentakkiRulesetSettings.BreakOverrideVolumeValue, 0.5, 0, 1, 0.01f);
+            SetDefault(SentakkiRulesetSettings.BreakSampleVolume, 1d, 0d, 1d, 0.01f);
         }
     }
 
@@ -55,7 +53,6 @@ namespace osu.Game.Rulesets.Sentakki.Configuration
         LaneInputMode,
         SnakingSlideBody,
         DetailedJudgements,
-        BreakOverrideVolumeToggle,
-        BreakOverrideVolumeValue
+        BreakSampleVolume
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
@@ -42,8 +42,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             if (!NeedBreakSample || !Break)
                 return Array.Empty<HitSampleInfo>();
 
-            Console.WriteLine(SampleControlPoint.SampleVolume);
-
             return new[]
             {
                 new SentakkiHitSampleInfo("Break", SampleControlPoint.SampleVolume)

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
@@ -26,7 +26,6 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             set => LaneBindable.Value = value;
         }
 
-
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
             base.CreateNestedHitObjects(cancellationToken);

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiLanedHitObject.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using osu.Framework.Bindables;
+using osu.Game.Audio;
 using osu.Game.Rulesets.Objects;
 
 namespace osu.Game.Rulesets.Sentakki.Objects
@@ -23,22 +26,29 @@ namespace osu.Game.Rulesets.Sentakki.Objects
             set => LaneBindable.Value = value;
         }
 
+
         protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
         {
             base.CreateNestedHitObjects(cancellationToken);
 
             if (Break)
-            {
                 for (int i = 0; i < 4; ++i)
-                {
-                    var nestedObject = new ScorePaddingObject() { StartTime = this.GetEndTime() };
+                    AddNested(new ScorePaddingObject() { StartTime = this.GetEndTime() });
+        }
 
-                    if (i == 0 && NeedBreakSample)
-                        nestedObject.Samples.Add(new SentakkiHitSampleInfo("Break"));
+        public override IList<HitSampleInfo> AuxiliarySamples => CreateBreakSample();
 
-                    AddNested(nestedObject);
-                }
-            }
+        public HitSampleInfo[] CreateBreakSample()
+        {
+            if (!NeedBreakSample || !Break)
+                return Array.Empty<HitSampleInfo>();
+
+            Console.WriteLine(SampleControlPoint.SampleVolume);
+
+            return new[]
+            {
+                new SentakkiHitSampleInfo("Break", SampleControlPoint.SampleVolume)
+            };
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -1,4 +1,5 @@
 ﻿using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
@@ -27,6 +28,9 @@ namespace osu.Game.Rulesets.Sentakki.UI
             // for an odd reason, Config seems to be passed as null when creating it. doesnt even get called...
             if (config == null)
                 return;
+
+            Bindable<double> breakVolume;
+            Bindable<bool> breakOverrideToggle;
 
             Children = new Drawable[]
             {
@@ -76,7 +80,22 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     LabelText = "Lane input mode (Doesn't apply to touch)",
                     Current = config.GetBindable<LaneInputMode>(SentakkiRulesetSettings.LaneInputMode)
                 },
+
+                new SettingsCheckbox
+                {
+                    LabelText = "Break sample volume override",
+                    Current = breakOverrideToggle = config.GetBindable<bool>(SentakkiRulesetSettings.BreakOverrideVolumeToggle),
+                    TooltipText = "Use a constant volume level as the Break sample volume instead of the underlying HitObject sample volume."
+                },
+                new SettingsSlider<double, BreakVolumeSlider>{
+                    LabelText = "Break sample volume",
+                    Current = breakVolume = config.GetBindable<double>(SentakkiRulesetSettings.BreakOverrideVolumeValue),
+                    KeyboardStep = 0.01f,
+                    DisplayAsPercentage = true,
+                }
             };
+
+            breakOverrideToggle.BindValueChanged(v => breakVolume.Disabled = !v.NewValue, true);
         }
 
         private class NoteTimeSlider : OsuSliderBar<double>
@@ -104,6 +123,11 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 return speed.ToString();
             }
             public override LocalisableString TooltipText => Current.Value.ToString("N0") + "ms (" + speedRating() + ")";
+        }
+
+        private class BreakVolumeSlider : OsuSliderBar<double>
+        {
+            public override LocalisableString TooltipText => Current.Disabled ? "Enable Break sample volume override to set Break volume." : base.TooltipText;
         }
     }
 }

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -24,10 +24,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
         {
             var config = (SentakkiRulesetConfigManager)Config;
 
-            // for an odd reason, Config seems to be passed as null when creating it. doesnt even get called...
-            if (config == null)
-                return;
-
             Children = new Drawable[]
             {
                 new SettingsCheckbox
@@ -76,8 +72,8 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     LabelText = "Lane input mode (Doesn't apply to touch)",
                     Current = config.GetBindable<LaneInputMode>(SentakkiRulesetSettings.LaneInputMode)
                 },
-
-                new SettingsSlider<double, OsuSliderBar<double>>{
+                new SettingsSlider<double, OsuSliderBar<double>>
+                {
                     LabelText = "Break sample volume",
                     Current = config.GetBindable<double>(SentakkiRulesetSettings.BreakSampleVolume),
                     KeyboardStep = 0.01f,
@@ -99,6 +95,7 @@ namespace osu.Game.Rulesets.Sentakki.UI
             }
             public override LocalisableString TooltipText => Current.Value.ToString("N0") + "ms (" + speedRating() + ")";
         }
+
         private class TouchTimeSlider : OsuSliderBar<double>
         {
             private string speedRating()

--- a/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/SentakkiSettingsSubsection.cs
@@ -1,5 +1,4 @@
 ﻿using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
@@ -28,9 +27,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
             // for an odd reason, Config seems to be passed as null when creating it. doesnt even get called...
             if (config == null)
                 return;
-
-            Bindable<double> breakVolume;
-            Bindable<bool> breakOverrideToggle;
 
             Children = new Drawable[]
             {
@@ -81,21 +77,13 @@ namespace osu.Game.Rulesets.Sentakki.UI
                     Current = config.GetBindable<LaneInputMode>(SentakkiRulesetSettings.LaneInputMode)
                 },
 
-                new SettingsCheckbox
-                {
-                    LabelText = "Break sample volume override",
-                    Current = breakOverrideToggle = config.GetBindable<bool>(SentakkiRulesetSettings.BreakOverrideVolumeToggle),
-                    TooltipText = "Use a constant volume level as the Break sample volume instead of the underlying HitObject sample volume."
-                },
-                new SettingsSlider<double, BreakVolumeSlider>{
+                new SettingsSlider<double, OsuSliderBar<double>>{
                     LabelText = "Break sample volume",
-                    Current = breakVolume = config.GetBindable<double>(SentakkiRulesetSettings.BreakOverrideVolumeValue),
+                    Current = config.GetBindable<double>(SentakkiRulesetSettings.BreakSampleVolume),
                     KeyboardStep = 0.01f,
                     DisplayAsPercentage = true,
                 }
             };
-
-            breakOverrideToggle.BindValueChanged(v => breakVolume.Disabled = !v.NewValue, true);
         }
 
         private class NoteTimeSlider : OsuSliderBar<double>
@@ -123,11 +111,6 @@ namespace osu.Game.Rulesets.Sentakki.UI
                 return speed.ToString();
             }
             public override LocalisableString TooltipText => Current.Value.ToString("N0") + "ms (" + speedRating() + ")";
-        }
-
-        private class BreakVolumeSlider : OsuSliderBar<double>
-        {
-            public override LocalisableString TooltipText => Current.Disabled ? "Enable Break sample volume override to set Break volume." : base.TooltipText;
         }
     }
 }


### PR DESCRIPTION
This PR implements the ability for players to adjust the volume of break samples, since some converts may have more break notes than regular notes, completely drowning the music behind.