### PR TITLE
Reduce minimum duration for slides during conversion

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiSlidePath.cs
@@ -12,7 +12,7 @@ namespace osu.Game.Rulesets.Sentakki.Objects
         public readonly int EndLane;
 
         // The minimum duration that this pattern can have, used in converts
-        public double MinDuration => TotalDistance / 2;
+        public double MinDuration => TotalDistance / 5;
 
         // The maximum duration that this pattern can have, used in converts.
         // While it is completely playable even beyond this value, it would look awkward for shorter slides


### PR DESCRIPTION
Previous minimums unintentionally accounted for the shoot delay, which wasn't considered by the converter, hence requiring a larger minimum to make semi-decent slides.

By making the converter take into account shoot offset during generation, this minimum doesn't need to take converter quirks into account.

Converter will also never generate slides with an offset of 0 from now on.

