### PR TITLE
Don't apply miss colour to hit object names

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
+++ b/osu.Game.Rulesets.Sentakki/Statistics/JudgementChart.cs
@@ -62,7 +62,7 @@ public partial class JudgementChart : TableContainer
             int sum = results.Sum(kvp => kvp.Value);
 
             HitResult minResult = sum == 0 ? HitResult.Perfect : results.MinBy(kvp => kvp.Key).Key;
-            ColourInfo specialColor = colours.ForSentakkiResult(minResult);
+            ColourInfo specialColor = minResult is HitResult.Miss ? Color4.LightGray : colours.ForSentakkiResult(minResult);
 
             // The alpha will be used to "disable" an hitobject entry if they don't exist
             float commonAlpha = sum == 0 ? 0.1f : 1;


### PR DESCRIPTION
Having any miss made it red. It seemed too aggressive, and it feels like the player missed everything instead.

<img width="1679" height="540" alt="image" src="https://github.com/user-attachments/assets/2e62e509-68f4-4571-b473-ac1dad22c6b9" />
