### PR TITLE
Implement basic editor functionality

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/TestSceneSentakkiEditor.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/TestSceneSentakkiEditor.cs
@@ -1,0 +1,10 @@
+using NUnit.Framework;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Sentakki.Tests;
+
+[TestFixture]
+public partial class TestSceneSentakkiEditor : EditorTestScene
+{
+    protected override Ruleset CreateEditorRuleset() => new SentakkiRuleset();
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
@@ -75,10 +75,10 @@ public partial class HoldPlacementBlueprint : SentakkiPlacementBlueprint<Hold>
         return base.UpdateTimeAndPosition(screenSpacePosition, time);
     }
 
-    protected override bool OnClick(ClickEvent e)
+    protected override bool OnMouseDown(MouseDownEvent e)
     {
         if (e.Button is not MouseButton.Left)
-            return base.OnClick(e);
+            return base.OnMouseDown(e);
 
         switch (PlacementActive)
         {
@@ -92,6 +92,6 @@ public partial class HoldPlacementBlueprint : SentakkiPlacementBlueprint<Hold>
                 return true;
         }
 
-        return base.OnClick(e);
+        return base.OnMouseDown(e);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
@@ -1,0 +1,97 @@
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Configuration;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Sentakki.UI;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
+
+public partial class HoldPlacementBlueprint : SentakkiPlacementBlueprint<Hold>
+{
+    public HoldPlacementBlueprint()
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = new HoldBody()
+        {
+            Colour = Color4.YellowGreen,
+            Alpha = 0.5f,
+        };
+    }
+
+    private readonly Bindable<float> animationSpeed = new Bindable<float>(5);
+
+    [BackgroundDependencyLoader]
+    private void load(SentakkiRulesetConfigManager configs)
+    {
+        configs.BindWith(SentakkiRulesetSettings.AnimationSpeed, animationSpeed);
+    }
+
+    protected override void Update()
+    {
+        Rotation = HitObject.Lane.GetRotationForLane();
+
+        const float max_height = SentakkiPlayfield.INTERSECTDISTANCE - SentakkiPlayfield.NOTESTARTDISTANCE;
+        double animationDuration = DrawableSentakkiRuleset.ComputeLaneNoteEntryTime(animationSpeed.Value) / 2;
+
+        // TODO: Needs better variable names
+        double headY = Math.Min(HitObject.StartTime - EditorClock.CurrentTime, animationDuration);
+        double tailY = Math.Min(HitObject.EndTime - EditorClock.CurrentTime, animationDuration);
+        double height = tailY - headY;
+
+        InternalChild.Y = (float)(-SentakkiPlayfield.INTERSECTDISTANCE + headY / animationDuration * max_height);
+        InternalChild.Height = (float)(height / animationDuration * max_height);
+    }
+
+    private double commitStartTime;
+
+    public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
+    {
+        switch (PlacementActive)
+        {
+            case PlacementState.Waiting:
+                float angle = ToScreenSpace(OriginPosition).AngleTo(screenSpacePosition);
+
+                HitObject.Lane = (int)Math.Round((angle - 22.5f) / 45);
+                break;
+
+            case PlacementState.Active:
+                // If the mapper maps the hold in reverse direction, we swap the start and end times to ensure correctness.
+                HitObject.StartTime = Math.Min(commitStartTime, time);
+                HitObject.EndTime = Math.Max(commitStartTime, time);
+                break;
+        }
+
+        return base.UpdateTimeAndPosition(screenSpacePosition, time);
+    }
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        if (e.Button is not MouseButton.Left)
+            return base.OnClick(e);
+
+        switch (PlacementActive)
+        {
+            case PlacementState.Waiting:
+                BeginPlacement(true);
+                commitStartTime = HitObject.StartTime;
+                return true;
+
+            case PlacementState.Active:
+                EndPlacement(true);
+                return true;
+        }
+
+        return base.OnClick(e);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldSelectionBlueprint.cs
@@ -1,0 +1,37 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
+
+public partial class HoldSelectionBlueprint : SentakkiSelectionBlueprint<Hold, DrawableHold>
+{
+    private readonly HoldBody highlight;
+
+    public override Quad SelectionQuad => highlight.ScreenSpaceDrawQuad;
+
+    public HoldSelectionBlueprint(Hold item)
+        : base(item)
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = highlight = new HoldBody()
+        {
+            Colour = Color4.YellowGreen,
+            Alpha = 0.5f,
+        };
+    }
+
+    protected override void Update()
+    {
+        Rotation = HitObject.Lane.GetRotationForLane();
+        highlight.Y = DrawableObject.NoteBody.Y;
+        highlight.Scale = DrawableObject.NoteBody.Scale;
+        highlight.Height = DrawableObject.NoteBody.Height;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiPlacementBlueprint.cs
@@ -1,0 +1,14 @@
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Objects;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints;
+
+public partial class SentakkiPlacementBlueprint<T> : HitObjectPlacementBlueprint where T : SentakkiHitObject, new()
+{
+    public new T HitObject => (T)base.HitObject;
+
+    public SentakkiPlacementBlueprint()
+        : base(new T())
+    {
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiPlacementBlueprint.cs
@@ -1,3 +1,6 @@
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Sentakki.Objects;
 
@@ -10,5 +13,23 @@ public partial class SentakkiPlacementBlueprint<T> : HitObjectPlacementBlueprint
     public SentakkiPlacementBlueprint()
         : base(new T())
     {
+    }
+
+    private readonly Bindable<TernaryState> breakState = new Bindable<TernaryState>();
+    private readonly Bindable<TernaryState> exState = new Bindable<TernaryState>();
+
+    [BackgroundDependencyLoader]
+    private void load(SentakkiBlueprintContainer blueprintContainer)
+    {
+        var selectionHandler = (SentakkiSelectionHandler)blueprintContainer.SelectionHandler;
+
+        // We want to inherit the current state of the flag ternary buttons, similarly to hitobject samples.
+        // The samples are being set by `ComposeBlueprintContainer.ensurePlacementCreated`, which is not overridable.
+        // So we need to implement similar logic... here...
+        breakState.BindTo(selectionHandler.BreakTernaryState);
+        exState.BindTo(selectionHandler.ExTernaryState);
+
+        breakState.BindValueChanged(v => HitObject.Break = v.NewValue == TernaryState.True, true);
+        exState.BindValueChanged(v => HitObject.Ex = v.NewValue == TernaryState.True, true);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiSelectionBlueprint.cs
@@ -12,6 +12,8 @@ public abstract partial class SentakkiSelectionBlueprint<THitObject, TDrawable> 
     public override Vector2 ScreenSpaceSelectionPoint => SelectionQuad.Centre;
     public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => SelectionQuad.Contains(screenSpacePos);
 
+    protected override bool AlwaysShowWhenSelected => true;
+
     protected SentakkiSelectionBlueprint(THitObject item)
         : base(item)
     {

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiSelectionBlueprint.cs
@@ -1,0 +1,21 @@
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osuTK;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints;
+
+public abstract partial class SentakkiSelectionBlueprint<THitObject, TDrawable> : HitObjectSelectionBlueprint<THitObject>
+    where THitObject : SentakkiHitObject
+    where TDrawable : DrawableSentakkiHitObject
+{
+    public override Vector2 ScreenSpaceSelectionPoint => SelectionQuad.Centre;
+    public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => SelectionQuad.Contains(screenSpacePos);
+
+    protected SentakkiSelectionBlueprint(THitObject item)
+        : base(item)
+    {
+    }
+
+    public new TDrawable DrawableObject => (TDrawable)base.DrawableObject;
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideBodyHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideBodyHighlight.cs
@@ -14,10 +14,14 @@ public partial class SlideBodyHighlight : CompositeDrawable
 
     public Quad SelectionQuad => slideVisual.ScreenSpaceDrawQuad;
 
+    private readonly SlideBodyInfo slideBodyInfo;
+
     public SlideBodyHighlight(SlideBodyInfo slideBodyInfo)
     {
         Anchor = Anchor.Centre;
         Origin = Anchor.Centre;
+
+        this.slideBodyInfo = slideBodyInfo;
 
         starPieces = new StarPiece[3];
 
@@ -37,7 +41,6 @@ public partial class SlideBodyHighlight : CompositeDrawable
                 [
                     slideVisual = new SlideVisual
                     {
-                        SlideBodyInfo = slideBodyInfo
                     },
                     new Container
                     {
@@ -62,5 +65,17 @@ public partial class SlideBodyHighlight : CompositeDrawable
             localStar.Rotation = dhoStar.Rotation;
             localStar.Position = dhoStar.Position;
         }
+    }
+
+    public override void Show()
+    {
+        slideVisual.SlideBodyInfo = slideBodyInfo;
+        base.Show();
+    }
+
+    public override void Hide()
+    {
+        base.Hide();
+        slideVisual.SlideBodyInfo = null;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideBodyHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideBodyHighlight.cs
@@ -1,0 +1,66 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
+
+public partial class SlideBodyHighlight : CompositeDrawable
+{
+    private readonly StarPiece[] starPieces;
+    private readonly SlideVisual slideVisual;
+
+    public Quad SelectionQuad => slideVisual.ScreenSpaceDrawQuad;
+
+    public SlideBodyHighlight(SlideBodyInfo slideBodyInfo)
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        starPieces = new StarPiece[3];
+
+        for (int i = 0; i < 3; ++i)
+            starPieces[i] = new StarPiece();
+
+        InternalChildren =
+        [
+            new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                // Slide paths are built with the assumption that it will always start from Lane 0
+                // We apply a counter rotation so that the visuals line up when lane rotation is applied at a higher level.
+                Rotation = -22.5f,
+                Children =
+                [
+                    slideVisual = new SlideVisual
+                    {
+                        SlideBodyInfo = slideBodyInfo
+                    },
+                    new Container
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Children = starPieces,
+                    }
+                ]
+            }
+        ];
+    }
+
+    public void UpdateFrom(DrawableSlideBody drawableObject)
+    {
+        for (int i = 0; i < starPieces.Length; ++i)
+        {
+            var localStar = starPieces[i];
+            var dhoStar = drawableObject.SlideStars[i];
+
+            localStar.Alpha = dhoStar.Alpha;
+            localStar.Scale = dhoStar.Scale;
+            localStar.Rotation = dhoStar.Rotation;
+            localStar.Position = dhoStar.Position;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
@@ -55,7 +55,7 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
     {
         base.Update();
 
-        Rotation = HitObject.Lane.GetRotationForLane();
+        InternalChild.Rotation = HitObject.Lane.GetRotationForLane();
         tapHighlight.Y = -SentakkiPlayfield.INTERSECTDISTANCE;
     }
 
@@ -121,12 +121,17 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
 
     public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
     {
-        float angle = ToScreenSpace(OriginPosition).AngleTo(screenSpacePosition);
+        var localPosition = ToLocalSpace(screenSpacePosition);
+        float angle = OriginPosition.AngleTo(localPosition);
+
         int targetLane = (int)Math.Round((angle - 22.5f) / 45);
 
         switch (PlacementActive)
         {
             case PlacementState.Waiting:
+                if (Vector2.Distance(OriginPosition, localPosition) < 100)
+                    break;
+
                 HitObject.Lane = targetLane;
                 break;
 
@@ -136,6 +141,10 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
                 double endTime = Math.Max(commitStartTime, time);
 
                 HitObject.SlideInfoList[0].Duration = endTime - HitObject.StartTime;
+
+                // Yes this distance is higher, since slide bodies feel worse
+                if (Vector2.Distance(OriginPosition, localPosition) < 200)
+                    break;
 
                 int startLane = HitObject.Lane + currentBody.RelativeEndLane - segments[^1].RelativeEndLane;
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
@@ -51,12 +51,24 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
         });
     }
 
+    private bool initialStateApplied;
+
     protected override void Update()
     {
         base.Update();
+        float newRotation = HitObject.Lane.GetRotationForLane();
 
-        InternalChild.Rotation = HitObject.Lane.GetRotationForLane();
         tapHighlight.Y = -SentakkiPlayfield.INTERSECTDISTANCE;
+
+        if (!initialStateApplied)
+        {
+            InternalChild.Rotation = newRotation;
+            initialStateApplied = true;
+            return;
+        }
+
+        float angleDelta = MathExtensions.AngleDelta(InternalChild.Rotation, newRotation);
+        InternalChild.Rotation += 25 * angleDelta * (float)(Time.Elapsed / 1000);
     }
 
     private double commitStartTime;

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+using osu.Game.Rulesets.Sentakki.UI;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
+
+public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
+{
+    private readonly SlideTapPiece tapHighlight;
+
+    protected override bool IsValidForPlacement => base.IsValidForPlacement && HitObject.SlideInfoList[0].Segments.Count > 0;
+
+    public SlidePlacementBlueprint()
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        HitObject.SlideInfoList = [new SlideBodyInfo()];
+
+        AddInternal(new Container
+        {
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Colour = Color4.YellowGreen,
+            Children =
+            [
+                new SlideVisual
+                {
+                    Rotation = -22.5f,
+                    SlideBodyInfo = currentBody,
+                },
+                tapHighlight = new SlideTapPiece
+                {
+                    Alpha = 0.5f,
+
+                    Scale = Vector2.One,
+                    SecondStar = { Alpha = 0 }
+                }
+            ]
+        });
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        Rotation = HitObject.Lane.GetRotationForLane();
+        tapHighlight.Y = -SentakkiPlayfield.INTERSECTDISTANCE;
+    }
+
+    private double commitStartTime;
+
+    protected override bool OnMouseDown(MouseDownEvent e)
+    {
+        switch (PlacementActive)
+        {
+            case PlacementState.Waiting:
+                if (e.Button is not MouseButton.Left)
+                    break;
+
+                BeginPlacement(true);
+                updateSlideVisual();
+                commitStartTime = HitObject.StartTime;
+                return true;
+
+            case PlacementState.Active:
+                switch (e.Button)
+                {
+                    case MouseButton.Left:
+                        segments.Add(segments[^1]);
+
+                        commitChange();
+                        updateSlideVisual();
+                        return true;
+
+                    case MouseButton.Middle:
+                        if (HitObject.SlideInfoList[0].Segments.Count == 0)
+                            break;
+
+                        segments.RemoveAt(segments.Count - 1);
+
+                        commitChange();
+                        updateSlideVisual();
+                        return true;
+
+                    case MouseButton.Right:
+                        EndPlacement(true);
+                        return true;
+                }
+
+                break;
+        }
+
+        return base.OnMouseDown(e);
+    }
+
+    private readonly SlideBodyInfo currentBody = new SlideBodyInfo();
+
+    private readonly List<SlideSegment> segments = [new SlideSegment(PathShape.Straight, 4, false)];
+
+    private void updateSlideVisual()
+    {
+        currentBody.Segments = segments;
+    }
+
+    private void commitChange()
+    {
+        HitObject.SlideInfoList[0].Segments = segments[..^1];
+    }
+
+    public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
+    {
+        float angle = ToScreenSpace(OriginPosition).AngleTo(screenSpacePosition);
+        int targetLane = (int)Math.Round((angle - 22.5f) / 45);
+
+        switch (PlacementActive)
+        {
+            case PlacementState.Waiting:
+                HitObject.Lane = targetLane;
+                break;
+
+            case PlacementState.Active:
+                // If the mapper maps the hold in reverse direction, we swap the start and end times to ensure correctness.
+                HitObject.StartTime = Math.Min(commitStartTime, time);
+                double endTime = Math.Max(commitStartTime, time);
+
+                HitObject.SlideInfoList[0].Duration = endTime - HitObject.StartTime;
+
+                int startLane = HitObject.Lane + currentBody.RelativeEndLane - segments[^1].RelativeEndLane;
+
+                var newSegment = segments[^1] with { RelativeEndLane = targetLane - startLane };
+
+                if (!SlidePaths.CheckSlideValidity(newSegment))
+                    break;
+
+                segments[^1] = newSegment;
+                updateSlideVisual();
+                break;
+        }
+
+        return base.UpdateTimeAndPosition(screenSpacePosition, time);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
@@ -20,6 +20,8 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
     private readonly SlideTapPiece tapHighlight;
 
     private readonly SlideBodyInfo committedSlideInfo;
+
+    private readonly SlideVisual commitedSlideVisual;
     private readonly SlideVisual activeSegmentVisual;
 
     protected override bool IsValidForPlacement => base.IsValidForPlacement && HitObject.SlideInfoList[0].Segments.Count > 0;
@@ -38,7 +40,7 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
             Colour = Color4.YellowGreen,
             Children =
             [
-                new SlideVisual
+                commitedSlideVisual = new SlideVisual
                 {
                     Rotation = -22.5f,
                     Alpha = 0.5f,
@@ -197,5 +199,14 @@ public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
         activeSegmentVisual.SlideBodyInfo!.Segments = [currentSegment];
 
         return true;
+    }
+
+    public override void EndPlacement(bool commit)
+    {
+        base.EndPlacement(commit);
+
+        // Return the chevrons to the pool when placement ends
+        commitedSlideVisual.SlideBodyInfo = null;
+        activeSegmentVisual.SlideBodyInfo = null;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
+
+public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide, DrawableSlide>
+{
+    private readonly SlideBodyHighlight[] slideBodyHighlights;
+    private readonly SlideTapPiece slideTapHighlight;
+
+    public override Quad SelectionQuad => slideTapHighlight.ScreenSpaceDrawQuad;
+
+    public SlideSelectionBlueprint(Slide item)
+        : base(item)
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        slideBodyHighlights = [.. item.SlideBodies.Select(sb => new SlideBodyHighlight(sb.SlideBodyInfo))];
+
+        InternalChildren =
+        [
+            new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Alpha = 0.5f,
+                Colour = Color4.YellowGreen,
+                Children = slideBodyHighlights
+            },
+            slideTapHighlight = new SlideTapPiece
+            {
+                Alpha = 0.5f,
+                Colour = Color4.YellowGreen,
+            },
+        ];
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        Rotation = HitObject.Lane.GetRotationForLane();
+
+        SlideTapPiece tapVisual = (SlideTapPiece)DrawableObject.SlideTaps.Child.TapVisual;
+
+        slideTapHighlight.Stars.Rotation = tapVisual.Stars.Rotation;
+        slideTapHighlight.SecondStar.Alpha = tapVisual.SecondStar.Alpha;
+        slideTapHighlight.Scale = tapVisual.Scale;
+        slideTapHighlight.Y = tapVisual.Y;
+
+        for (int i = 0; i < slideBodyHighlights.Length; ++i)
+            slideBodyHighlights[i].UpdateFrom(DrawableObject.SlideBodies[i]);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
@@ -43,6 +43,21 @@ public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide,
         ];
     }
 
+    protected override void OnDeselected()
+    {
+        base.OnDeselected();
+
+        foreach (var sbh in slideBodyHighlights)
+            sbh.Hide();
+    }
+
+    protected override void OnSelected()
+    {
+        base.OnSelected();
+        foreach (var sbh in slideBodyHighlights)
+            sbh.Show();
+    }
+
     protected override void Update()
     {
         base.Update();

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
@@ -1,5 +1,6 @@
 using System;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Sentakki.Extensions;
@@ -21,23 +22,33 @@ public partial class TapPlacementBlueprint : SentakkiPlacementBlueprint<Tap>
         Anchor = Anchor.Centre;
         Origin = Anchor.Centre;
 
-        InternalChild = highlight = new TapPiece()
+        InternalChild = new Container
         {
-            Alpha = 0.5f,
-            Colour = Color4.YellowGreen
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Child = highlight = new TapPiece
+            {
+                Alpha = 0.5f,
+                Colour = Color4.YellowGreen
+            }
         };
     }
 
     protected override void Update()
     {
         base.Update();
-        Rotation = HitObject.Lane.GetRotationForLane();
+        InternalChild.Rotation = HitObject.Lane.GetRotationForLane();
         highlight.Y = -SentakkiPlayfield.INTERSECTDISTANCE;
     }
 
     public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
     {
-        float angle = ToScreenSpace(OriginPosition).AngleTo(screenSpacePosition);
+        var localPosition = ToLocalSpace(screenSpacePosition);
+
+        if (Vector2.Distance(OriginPosition, localPosition) < 100)
+            return base.UpdateTimeAndPosition(screenSpacePosition, time);
+
+        float angle = OriginPosition.AngleTo(localPosition);
 
         HitObject.Lane = (int)Math.Round((angle - 22.5f) / 45);
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
@@ -1,0 +1,54 @@
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
+using osu.Game.Rulesets.Sentakki.UI;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
+
+public partial class TapPlacementBlueprint : SentakkiPlacementBlueprint<Tap>
+{
+    private readonly TapPiece highlight;
+
+    public TapPlacementBlueprint()
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = highlight = new TapPiece()
+        {
+            Alpha = 0.5f,
+            Colour = Color4.YellowGreen
+        };
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+        Rotation = HitObject.Lane.GetRotationForLane();
+        highlight.Y = -SentakkiPlayfield.INTERSECTDISTANCE;
+    }
+
+    public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
+    {
+        float angle = ToScreenSpace(OriginPosition).AngleTo(screenSpacePosition);
+
+        HitObject.Lane = (int)Math.Round((angle - 22.5f) / 45);
+
+        return base.UpdateTimeAndPosition(screenSpacePosition, time);
+    }
+
+    protected override bool OnMouseDown(MouseDownEvent e)
+    {
+        if (e.Button != MouseButton.Left) return false;
+
+        EndPlacement(true);
+        return true;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
@@ -34,11 +34,23 @@ public partial class TapPlacementBlueprint : SentakkiPlacementBlueprint<Tap>
         };
     }
 
+    private bool initialStateApplied;
+
     protected override void Update()
     {
         base.Update();
-        InternalChild.Rotation = HitObject.Lane.GetRotationForLane();
+        float newRotation = HitObject.Lane.GetRotationForLane();
+
         highlight.Y = -SentakkiPlayfield.INTERSECTDISTANCE;
+
+        if (!initialStateApplied)
+        {
+            InternalChild.Rotation = newRotation;
+            initialStateApplied = true;
+        }
+
+        float angleDelta = MathExtensions.AngleDelta(InternalChild.Rotation, newRotation);
+        InternalChild.Rotation += 25 * angleDelta * (float)(Time.Elapsed / 1000);
     }
 
     public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapSelectionBlueprint.cs
@@ -1,0 +1,36 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
+
+public partial class TapSelectionBlueprint : SentakkiSelectionBlueprint<Tap, DrawableTap>
+{
+    private readonly TapPiece highlight;
+    public override Quad SelectionQuad => DrawableObject.TapVisual.ScreenSpaceDrawQuad;
+
+    public TapSelectionBlueprint(Tap item)
+        : base(item)
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        AddInternal(highlight = new TapPiece
+        {
+            Alpha = 0.5f,
+            Colour = Color4.YellowGreen
+        });
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+        Rotation = HitObject.Lane.GetRotationForLane();
+        highlight.Scale = DrawableObject.TapVisual.Scale;
+        highlight.Y = DrawableObject.TapVisual.Y;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
@@ -83,7 +83,6 @@ public partial class TouchHoldPlacementBlueprint : SentakkiPlacementBlueprint<To
                 break;
         }
 
-        EndPlacement(true);
         return true;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
+
+public partial class TouchHoldPlacementBlueprint : SentakkiPlacementBlueprint<TouchHold>
+{
+    [Cached]
+    private IBindable<IReadOnlyList<Color4>>? paletteBindable { get; set; }
+        = new Bindable<IReadOnlyList<Color4>>(TouchHoldSelectionBlueprint.SELECTION_PALETTE);
+
+    private readonly TouchHoldBody highlight;
+
+    public TouchHoldPlacementBlueprint()
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = highlight = new TouchHoldBody
+        {
+            Alpha = 0.5f,
+        };
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        highlight.Position = HitObject.Position;
+    }
+
+    private double commitStartTime;
+
+    public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
+    {
+        switch (PlacementActive)
+        {
+            case PlacementState.Waiting:
+                Vector2 localPos = ToLocalSpace(screenSpacePosition);
+                HitObject.Position = localPos - OriginPosition;
+                break;
+
+            case PlacementState.Active:
+                HitObject.EndTime = Math.Max(commitStartTime, EditorClock.CurrentTime);
+                HitObject.StartTime = Math.Min(commitStartTime, EditorClock.CurrentTime);
+
+                break;
+        }
+
+        return base.UpdateTimeAndPosition(screenSpacePosition, time);
+    }
+
+    protected override bool OnMouseDown(MouseDownEvent e)
+    {
+        if (e.Button is not MouseButton.Left)
+            return base.OnMouseDown(e);
+
+        switch (PlacementActive)
+        {
+            case PlacementState.Waiting:
+                BeginPlacement(true);
+                commitStartTime = HitObject.StartTime;
+                break;
+
+            case PlacementState.Active:
+                EndPlacement(true);
+                break;
+        }
+
+        EndPlacement(true);
+        return true;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
@@ -46,8 +46,14 @@ public partial class TouchHoldPlacementBlueprint : SentakkiPlacementBlueprint<To
         switch (PlacementActive)
         {
             case PlacementState.Waiting:
-                Vector2 localPos = ToLocalSpace(screenSpacePosition);
-                HitObject.Position = localPos - OriginPosition;
+                Vector2 localPos = ToLocalSpace(screenSpacePosition) - OriginPosition;
+
+                // Touch notes cannot be placed more than 270 units away from the centre
+                float distance = Math.Min(localPos.Length, 270);
+
+                Vector2 clampedPosition = localPos.Normalized() * distance;
+                HitObject.Position = clampedPosition;
+
                 break;
 
             case PlacementState.Active:

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldSelectionBlueprint.cs
@@ -13,7 +13,7 @@ namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
 
 public partial class TouchHoldSelectionBlueprint : SentakkiSelectionBlueprint<TouchHold, DrawableTouchHold>
 {
-    private static readonly IReadOnlyList<Color4> palette =
+    public static readonly IReadOnlyList<Color4> SELECTION_PALETTE =
     [
         Color4.YellowGreen,
         Color4.YellowGreen.Darken(0.5f),
@@ -23,7 +23,7 @@ public partial class TouchHoldSelectionBlueprint : SentakkiSelectionBlueprint<To
 
     // TouchHoldBody typically relies on colour provided by DrawableTouchHold to set its colour. Since the highlight is not tied to a DHO, we provide that dependency here.
     [Cached]
-    private Bindable<IReadOnlyList<Color4>>? paletteBindable { get; set; } = new Bindable<IReadOnlyList<Color4>>(palette);
+    private Bindable<IReadOnlyList<Color4>>? paletteBindable { get; set; } = new Bindable<IReadOnlyList<Color4>>(SELECTION_PALETTE);
 
     private readonly TouchHoldBody highlight;
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldSelectionBlueprint.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.TouchHolds;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
+
+public partial class TouchHoldSelectionBlueprint : SentakkiSelectionBlueprint<TouchHold, DrawableTouchHold>
+{
+    private static readonly IReadOnlyList<Color4> palette =
+    [
+        Color4.YellowGreen,
+        Color4.YellowGreen.Darken(0.5f),
+        Color4.YellowGreen,
+        Color4.YellowGreen.Darken(0.5f),
+    ];
+
+    // TouchHoldBody typically relies on colour provided by DrawableTouchHold to set its colour. Since the highlight is not tied to a DHO, we provide that dependency here.
+    [Cached]
+    private Bindable<IReadOnlyList<Color4>>? paletteBindable { get; set; } = new Bindable<IReadOnlyList<Color4>>(palette);
+
+    private readonly TouchHoldBody highlight;
+
+    public override Quad SelectionQuad => highlight.ProgressPiece.ScreenSpaceDrawQuad;
+
+    public TouchHoldSelectionBlueprint(TouchHold item)
+        : base(item)
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = highlight = new TouchHoldBody
+        {
+            Alpha = 0.5f
+        };
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        highlight.Position = HitObject.Position;
+
+        var drawableVisuals = DrawableObject.TouchHoldBody;
+
+        highlight.Size = drawableVisuals.Size;
+        highlight.CentrePiece.Alpha = drawableVisuals.CentrePiece.Alpha;
+        highlight.CompletedCentre.Alpha = drawableVisuals.CompletedCentre.Alpha;
+        highlight.ProgressPiece.ProgressBindable.Value = drawableVisuals.ProgressPiece.ProgressBindable.Value;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchPlacementBlueprint.cs
@@ -1,3 +1,4 @@
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
@@ -34,9 +35,13 @@ public partial class TouchPlacementBlueprint : SentakkiPlacementBlueprint<Touch>
 
     public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
     {
-        Vector2 localPos = ToLocalSpace(screenSpacePosition);
+        Vector2 localPos = ToLocalSpace(screenSpacePosition) - OriginPosition;
 
-        HitObject.Position = localPos - OriginPosition;
+        // Touch notes cannot be placed more than 270 units away from the centre
+        float distance = Math.Min(localPos.Length, 270);
+
+        Vector2 clampedPosition = localPos.Normalized() * distance;
+        HitObject.Position = clampedPosition;
 
         return base.UpdateTimeAndPosition(screenSpacePosition, time);
     }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchPlacementBlueprint.cs
@@ -1,0 +1,52 @@
+using osu.Framework.Graphics;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
+
+public partial class TouchPlacementBlueprint : SentakkiPlacementBlueprint<Touch>
+{
+    private readonly TouchBody highlight;
+
+    public TouchPlacementBlueprint()
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = highlight = new TouchBody()
+        {
+            Alpha = 0.5f,
+            Colour = Color4.YellowGreen,
+        };
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        highlight.Position = HitObject.Position;
+    }
+
+    public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
+    {
+        Vector2 localPos = ToLocalSpace(screenSpacePosition);
+
+        HitObject.Position = localPos - OriginPosition;
+
+        return base.UpdateTimeAndPosition(screenSpacePosition, time);
+    }
+
+    protected override bool OnMouseDown(MouseDownEvent e)
+    {
+        if (e.Button is not MouseButton.Left)
+            return base.OnMouseDown(e);
+
+        EndPlacement(true);
+        return true;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchSelectionBlueprint.cs
@@ -1,0 +1,38 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Primitives;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Touches;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
+
+public partial class TouchSelectionBlueprint : SentakkiSelectionBlueprint<Touch, DrawableTouch>
+{
+    private readonly TouchBody highlight;
+
+    public override Quad SelectionQuad => highlight.ScreenSpaceDrawQuad;
+
+    public TouchSelectionBlueprint(Touch item)
+        : base(item)
+    {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
+
+        InternalChild = highlight = new TouchBody()
+        {
+            Alpha = 0.5f,
+            Colour = Color4.YellowGreen,
+        };
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        highlight.Position = DrawableObject.Position;
+
+        highlight.Size = DrawableObject.TouchBody.Size;
+        highlight.BorderContainer.Alpha = DrawableObject.TouchBody.BorderContainer.Alpha;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/HoldCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/HoldCompositionTool.cs
@@ -13,6 +13,6 @@ public class HoldCompositionTool : CompositionTool
     {
     }
 
-    public override Drawable? CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
-    public override PlacementBlueprint? CreatePlacementBlueprint() => new HoldPlacementBlueprint();
+    public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
+    public override PlacementBlueprint CreatePlacementBlueprint() => new HoldPlacementBlueprint();
 };

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/HoldCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/HoldCompositionTool.cs
@@ -1,0 +1,18 @@
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
+
+public class HoldCompositionTool : CompositionTool
+{
+    public HoldCompositionTool()
+        : base("Hold")
+    {
+    }
+
+    public override Drawable? CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
+    public override PlacementBlueprint? CreatePlacementBlueprint() => new HoldPlacementBlueprint();
+};

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/HoldCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/HoldCompositionTool.cs
@@ -15,4 +15,4 @@ public class HoldCompositionTool : CompositionTool
 
     public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Sliders);
     public override PlacementBlueprint CreatePlacementBlueprint() => new HoldPlacementBlueprint();
-};
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/SlideCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/SlideCompositionTool.cs
@@ -11,6 +11,14 @@ public class SlideCompositionTool : CompositionTool
     public SlideCompositionTool()
         : base("Slide")
     {
+        TooltipText =
+            """
+            Left click to place segment.
+            Middle click or Backspace to remove segment.
+            Alt+Scroll to change segment types
+            Alt+Click to mirror segment (if applicable)
+            Right click to finish.
+            """;
     }
 
     public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.Regular.Star };

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/SlideCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/SlideCompositionTool.cs
@@ -1,0 +1,19 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
+
+public class SlideCompositionTool : CompositionTool
+{
+    public SlideCompositionTool()
+        : base("Slide")
+    {
+    }
+
+    public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.Regular.Star };
+
+    public override PlacementBlueprint CreatePlacementBlueprint() => new SlidePlacementBlueprint();
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TapCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TapCompositionTool.cs
@@ -13,6 +13,6 @@ public class TapCompositionTool : CompositionTool
     {
     }
 
-    public override Drawable? CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
-    public override PlacementBlueprint? CreatePlacementBlueprint() => new TapPlacementBlueprint();
+    public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
+    public override PlacementBlueprint CreatePlacementBlueprint() => new TapPlacementBlueprint();
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TapCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TapCompositionTool.cs
@@ -1,0 +1,18 @@
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
+
+public class TapCompositionTool : CompositionTool
+{
+    public TapCompositionTool()
+        : base("Tap")
+    {
+    }
+
+    public override Drawable? CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Circles);
+    public override PlacementBlueprint? CreatePlacementBlueprint() => new TapPlacementBlueprint();
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TouchCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TouchCompositionTool.cs
@@ -1,0 +1,19 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
+
+public class TouchCompositionTool : CompositionTool
+{
+    public TouchCompositionTool()
+        : base("Touch")
+    {
+    }
+
+    public override Drawable CreateIcon() => new SpriteIcon { Icon = FontAwesome.Regular.HandPointRight };
+
+    public override PlacementBlueprint CreatePlacementBlueprint() => new TouchPlacementBlueprint();
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TouchHoldCompositionTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/CompositionTools/TouchHoldCompositionTool.cs
@@ -1,0 +1,18 @@
+using osu.Framework.Graphics;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
+
+public class TouchHoldCompositionTool : CompositionTool
+{
+    public TouchHoldCompositionTool()
+        : base("TouchHold")
+    {
+    }
+
+    public override Drawable CreateIcon() => new BeatmapStatisticIcon(BeatmapStatisticsIconType.Spinners);
+    public override PlacementBlueprint CreatePlacementBlueprint() => new TouchHoldPlacementBlueprint();
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/DrawableSentakkiEditorRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/DrawableSentakkiEditorRuleset.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Rulesets.UI;
+using osuTK;
+
+namespace osu.Game.Rulesets.Sentakki.Edit;
+
+public partial class DrawableSentakkiEditorRuleset : DrawableSentakkiRuleset
+{
+    public DrawableSentakkiEditorRuleset(SentakkiRuleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod>? mods) : base(ruleset, beatmap, mods)
+    {
+    }
+
+    public override PlayfieldAdjustmentContainer CreatePlayfieldAdjustmentContainer()
+    => new SentakkiPlayfieldAdjustmentContainer() { Size = new Vector2(0.9f) };
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using osu.Framework.Input.Events;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
+
+namespace osu.Game.Rulesets.Sentakki.Edit;
+
+public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
+{
+    public SentakkiBlueprintContainer(HitObjectComposer composer)
+        : base(composer)
+    {
+    }
+
+    protected override bool TryMoveBlueprints(DragEvent e, IList<(SelectionBlueprint<HitObject> blueprint, Vector2[] originalSnapPositions)> blueprints)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -3,6 +3,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
@@ -25,6 +26,9 @@ public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
         {
             case Tap t:
                 return new TapSelectionBlueprint(t);
+
+            case Hold h:
+                return new HoldSelectionBlueprint(h);
 
             default:
                 return base.CreateHitObjectBlueprintFor(hitObject);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
@@ -14,6 +15,8 @@ public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
     public SentakkiBlueprintContainer(HitObjectComposer composer)
         : base(composer)
     {
+        Anchor = Anchor.Centre;
+        Origin = Anchor.Centre;
     }
 
     public override HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject)

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -1,13 +1,17 @@
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -15,11 +19,16 @@ namespace osu.Game.Rulesets.Sentakki.Edit;
 
 public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
 {
+    [Cached]
+    private DrawablePool<SlideChevron> chevrons { get; set; }
+
     public SentakkiBlueprintContainer(HitObjectComposer composer)
         : base(composer)
     {
         Anchor = Anchor.Centre;
         Origin = Anchor.Centre;
+
+        AddInternal(chevrons = new DrawablePool<SlideChevron>(100));
     }
 
     public override HitObjectSelectionBlueprint? CreateHitObjectBlueprintFor(HitObject hitObject)
@@ -31,6 +40,9 @@ public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
 
             case Hold hold:
                 return new HoldSelectionBlueprint(hold);
+
+            case Slide slide:
+                return new SlideSelectionBlueprint(slide);
 
             case Touch touch:
                 return new TouchSelectionBlueprint(touch);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -5,6 +5,7 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
@@ -20,15 +21,18 @@ public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
         Origin = Anchor.Centre;
     }
 
-    public override HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject)
+    public override HitObjectSelectionBlueprint? CreateHitObjectBlueprintFor(HitObject hitObject)
     {
         switch (hitObject)
         {
-            case Tap t:
-                return new TapSelectionBlueprint(t);
+            case Tap tap:
+                return new TapSelectionBlueprint(tap);
 
-            case Hold h:
-                return new HoldSelectionBlueprint(h);
+            case Hold hold:
+                return new HoldSelectionBlueprint(hold);
+
+            case Touch touch:
+                return new TouchSelectionBlueprint(touch);
 
             default:
                 return base.CreateHitObjectBlueprintFor(hitObject);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
+using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -14,8 +16,20 @@ public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
     {
     }
 
+    public override HitObjectSelectionBlueprint CreateHitObjectBlueprintFor(HitObject hitObject)
+    {
+        switch (hitObject)
+        {
+            case Tap t:
+                return new TapSelectionBlueprint(t);
+
+            default:
+                return base.CreateHitObjectBlueprintFor(hitObject);
+        }
+    }
+
     protected override bool TryMoveBlueprints(DragEvent e, IList<(SelectionBlueprint<HitObject> blueprint, Vector2[] originalSnapPositions)> blueprints)
     {
-        throw new System.NotImplementedException();
+        return false;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -18,8 +18,11 @@ using osuTK;
 
 namespace osu.Game.Rulesets.Sentakki.Edit;
 
+[Cached]
 public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
 {
+    public new HitObjectComposer Composer => base.Composer;
+
     [Cached]
     private DrawablePool<SlideChevron> chevrons { get; set; }
 

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiBlueprintContainer.cs
@@ -6,6 +6,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
 using osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
+using osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
@@ -33,6 +34,9 @@ public partial class SentakkiBlueprintContainer : ComposeBlueprintContainer
 
             case Touch touch:
                 return new TouchSelectionBlueprint(touch);
+
+            case TouchHold touchHold:
+                return new TouchHoldSelectionBlueprint(touchHold);
 
             default:
                 return base.CreateHitObjectBlueprintFor(hitObject);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -1,8 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Sentakki.Edit;
@@ -16,6 +20,30 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
 
     protected override ComposeBlueprintContainer CreateBlueprintContainer()
         => new SentakkiBlueprintContainer(this);
+
+    protected override IEnumerable<Drawable> CreateTernaryButtons()
+    {
+        foreach (var ternaryButton in base.CreateTernaryButtons().Skip(1))
+            yield return ternaryButton;
+
+        var selectionHandler = (SentakkiSelectionHandler)BlueprintContainer.SelectionHandler;
+
+        yield return new DrawableTernaryButton
+        {
+            Current = selectionHandler.BreakTernaryState,
+            CreateIcon = () => new SpriteIcon { Icon = FontAwesome.Solid.WeightHanging },
+            Description = "Break",
+            TooltipText = "Increases the scoring weight of notes. Typically used to emphasize certain notes, or to increase punishment for inaccuracy."
+        };
+
+        yield return new DrawableTernaryButton
+        {
+            Current = selectionHandler.ExTernaryState,
+            CreateIcon = () => new SpriteIcon { Icon = FontAwesome.Solid.Seedling },
+            Description = "Ex",
+            TooltipText = "Increases the judgement leniency of notes. Typically used to provide a safety net for players, allowing harder patterns to be introduced."
+        };
+    }
 
     protected override IReadOnlyList<CompositionTool> CompositionTools { get; } =
     [

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -22,5 +22,6 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
         new TapCompositionTool(),
         new HoldCompositionTool(),
         new TouchCompositionTool(),
+        new TouchHoldCompositionTool(),
     ];
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 
@@ -16,5 +17,5 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
     protected override ComposeBlueprintContainer CreateBlueprintContainer()
         => new SentakkiBlueprintContainer(this);
 
-    protected override IReadOnlyList<CompositionTool> CompositionTools { get; } = [];
+    protected override IReadOnlyList<CompositionTool> CompositionTools { get; } = [new TapCompositionTool()];
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -3,8 +3,10 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.UI;
@@ -27,6 +29,9 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
 
     protected override ComposeBlueprintContainer CreateBlueprintContainer()
         => new SentakkiBlueprintContainer(this);
+
+    protected override DrawableRuleset<SentakkiHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
+    => new DrawableSentakkiEditorRuleset((SentakkiRuleset)ruleset, beatmap, mods);
 
     protected override IEnumerable<Drawable> CreateTernaryButtons()
     {

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
 using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 
@@ -17,6 +19,11 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
         : base(ruleset)
     {
     }
+
+    private DrawableRulesetDependencies dependencies = null!;
+
+    protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        => dependencies = new DrawableRulesetDependencies(Ruleset, base.CreateChildDependencies(parent));
 
     protected override ComposeBlueprintContainer CreateBlueprintContainer()
         => new SentakkiBlueprintContainer(this);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -65,4 +65,11 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
         new TouchCompositionTool(),
         new TouchHoldCompositionTool(),
     ];
+
+    protected override void Dispose(bool isDisposing)
+    {
+        base.Dispose(isDisposing);
+
+        dependencies?.Dispose();
+    }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -21,5 +21,6 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
     [
         new TapCompositionTool(),
         new HoldCompositionTool(),
+        new TouchCompositionTool(),
     ];
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -21,6 +21,7 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
     [
         new TapCompositionTool(),
         new HoldCompositionTool(),
+        new SlideCompositionTool(),
         new TouchCompositionTool(),
         new TouchHoldCompositionTool(),
     ];

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -17,5 +17,9 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
     protected override ComposeBlueprintContainer CreateBlueprintContainer()
         => new SentakkiBlueprintContainer(this);
 
-    protected override IReadOnlyList<CompositionTool> CompositionTools { get; } = [new TapCompositionTool()];
+    protected override IReadOnlyList<CompositionTool> CompositionTools { get; } =
+    [
+        new TapCompositionTool(),
+        new HoldCompositionTool(),
+    ];
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Edit.Tools;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+
+namespace osu.Game.Rulesets.Sentakki.Edit;
+
+public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitObject>
+{
+    public SentakkiHitObjectComposer(Ruleset ruleset)
+        : base(ruleset)
+    {
+    }
+
+    protected override ComposeBlueprintContainer CreateBlueprintContainer()
+        => new SentakkiBlueprintContainer(this);
+
+    protected override IReadOnlyList<CompositionTool> CompositionTools { get; } = [];
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Bindings;
 using osu.Game.Extensions;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
@@ -24,8 +25,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
     {
         Origin = Anchor.Centre;
         Anchor = Anchor.Centre;
-        exTernaryState.ValueChanged += v => applyTernaryChanges<SentakkiHitObject>(setExState, v.NewValue);
-        breakTernaryState.ValueChanged += v => applyTernaryChanges<SentakkiHitObject>(setBreakState, v.NewValue);
+        ExTernaryState.ValueChanged += v => applyTernaryChanges<SentakkiHitObject>(setExState, v.NewValue);
+        BreakTernaryState.ValueChanged += v => applyTernaryChanges<SentakkiHitObject>(setBreakState, v.NewValue);
 
         exSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setExSlideState, v.NewValue);
         breakSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setBreakSlideState, v.NewValue);
@@ -46,8 +47,16 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
         {
             Items =
             [
-                new TernaryStateToggleMenuItem("Break") { State = { BindTarget = breakTernaryState } },
-                new TernaryStateToggleMenuItem("EX ") { State = { BindTarget = exTernaryState } }
+                new TernaryStateToggleMenuItem("Break")
+                {
+                    State = { BindTarget = BreakTernaryState },
+                    Hotkey = new Hotkey(new KeyCombination(InputKey.R))
+                },
+                new TernaryStateToggleMenuItem("EX ")
+                {
+                    State = { BindTarget = ExTernaryState, },
+                    Hotkey = new Hotkey(new KeyCombination(InputKey.T))
+                }
             ]
         };
 
@@ -65,8 +74,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
         };
     }
 
-    private readonly Bindable<TernaryState> exTernaryState = new Bindable<TernaryState>();
-    private readonly Bindable<TernaryState> breakTernaryState = new Bindable<TernaryState>();
+    public readonly Bindable<TernaryState> ExTernaryState = new Bindable<TernaryState>();
+    public readonly Bindable<TernaryState> BreakTernaryState = new Bindable<TernaryState>();
 
     private readonly Bindable<TernaryState> exSlideTernaryState = new Bindable<TernaryState>();
     private readonly Bindable<TernaryState> breakSlideTernaryState = new Bindable<TernaryState>();
@@ -74,8 +83,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
     protected override void UpdateTernaryStates()
     {
         var selectedItems = SelectedItems.OfType<SentakkiHitObject>();
-        exTernaryState.Value = GetStateFromSelection(selectedItems, h => h.Ex);
-        breakTernaryState.Value = GetStateFromSelection(selectedItems, h => h.Break);
+        ExTernaryState.Value = GetStateFromSelection(selectedItems, h => h.Ex);
+        BreakTernaryState.Value = GetStateFromSelection(selectedItems, h => h.Break);
 
         var selectedSlideBodies = selectedItems.OfType<Slide>().SelectMany(s => s.SlideInfoList);
         breakSlideTernaryState.Value = GetStateFromSelection(selectedSlideBodies, s => s.Break);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Screens.Edit.Compose.Components;
+
+namespace osu.Game.Rulesets.Sentakki.Edit;
+
+public partial class SentakkiSelectionHandler : EditorSelectionHandler
+{
+    public SentakkiSelectionHandler()
+    {
+        exTernaryState.ValueChanged += v => applyTernaryChanges<SentakkiHitObject>(setExState, v.NewValue);
+        breakTernaryState.ValueChanged += v => applyTernaryChanges<SentakkiHitObject>(setBreakState, v.NewValue);
+
+        exSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setExSlideState, v.NewValue);
+        breakSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setBreakSlideState, v.NewValue);
+    }
+
+    #region TernaryStates
+
+    protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
+    {
+        foreach (var item in base.GetContextMenuItemsForSelection(selection))
+            yield return item;
+
+        yield return new OsuMenuItemSpacer();
+
+        var items = selection.Select(s => s.Item).OfType<SentakkiHitObject>();
+
+        yield return new TernaryStateToggleMenuItem("Break") { State = { BindTarget = breakTernaryState } };
+        yield return new TernaryStateToggleMenuItem("EX ") { State = { BindTarget = exTernaryState } };
+
+        var slideBodies = items.OfType<Slide>().SelectMany(s => s.SlideInfoList);
+
+        if (!slideBodies.Any()) yield break;
+
+        yield return new OsuMenuItemSpacer();
+
+        yield return new TernaryStateToggleMenuItem("Break slide") { State = { BindTarget = breakSlideTernaryState } };
+        yield return new TernaryStateToggleMenuItem("EX slide") { State = { BindTarget = exSlideTernaryState } };
+    }
+
+    private readonly Bindable<TernaryState> exTernaryState = new Bindable<TernaryState>();
+    private readonly Bindable<TernaryState> breakTernaryState = new Bindable<TernaryState>();
+
+    private readonly Bindable<TernaryState> exSlideTernaryState = new Bindable<TernaryState>();
+    private readonly Bindable<TernaryState> breakSlideTernaryState = new Bindable<TernaryState>();
+
+    protected override void UpdateTernaryStates()
+    {
+        var selectedItems = SelectedItems.OfType<SentakkiHitObject>();
+        exTernaryState.Value = GetStateFromSelection(selectedItems, h => h.Ex);
+        breakTernaryState.Value = GetStateFromSelection(selectedItems, h => h.Break);
+
+        var selectedSlideBodies = selectedItems.OfType<Slide>().SelectMany(s => s.SlideInfoList);
+        breakSlideTernaryState.Value = GetStateFromSelection(selectedSlideBodies, s => s.Break);
+    }
+
+    private void applyTernaryChanges<T>(Action<T, bool> applicator, TernaryState newTernaryState) where T : HitObject
+    {
+        var selectedItems = SelectedItems.OfType<T>();
+        bool newValue = newTernaryState is TernaryState.True;
+
+        EditorBeatmap.BeginChange();
+
+        foreach (var item in selectedItems)
+        {
+            applicator(item, newValue);
+            EditorBeatmap.Update(item);
+        }
+
+        EditorBeatmap.EndChange();
+    }
+
+    private void setExState(SentakkiHitObject hitObject, bool newValue) => hitObject.Ex = newValue;
+    private void setBreakState(SentakkiHitObject hitObject, bool newValue) => hitObject.Break = newValue;
+
+    private void setExSlideState(Slide slide, bool newValue) => slide.SlideInfoList.ForEach(si => si.Ex = newValue);
+    private void setBreakSlideState(Slide slide, bool newValue) => slide.SlideInfoList.ForEach(si => si.Ex = newValue);
+
+    #endregion
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -33,17 +33,27 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
 
         var items = selection.Select(s => s.Item).OfType<SentakkiHitObject>();
 
-        yield return new TernaryStateToggleMenuItem("Break") { State = { BindTarget = breakTernaryState } };
-        yield return new TernaryStateToggleMenuItem("EX ") { State = { BindTarget = exTernaryState } };
+        yield return new OsuMenuItem("Modifiers")
+        {
+            Items =
+            [
+                new TernaryStateToggleMenuItem("Break") { State = { BindTarget = breakTernaryState } },
+                new TernaryStateToggleMenuItem("EX ") { State = { BindTarget = exTernaryState } }
+            ]
+        };
 
         var slideBodies = items.OfType<Slide>().SelectMany(s => s.SlideInfoList);
 
         if (!slideBodies.Any()) yield break;
 
-        yield return new OsuMenuItemSpacer();
-
-        yield return new TernaryStateToggleMenuItem("Break slide") { State = { BindTarget = breakSlideTernaryState } };
-        yield return new TernaryStateToggleMenuItem("EX slide") { State = { BindTarget = exSlideTernaryState } };
+        yield return new OsuMenuItem("Slide Modifiers")
+        {
+            Items =
+            [
+                new TernaryStateToggleMenuItem("Break") { State = { BindTarget = breakSlideTernaryState } },
+                new TernaryStateToggleMenuItem("EX ") { State = { BindTarget = exSlideTernaryState } }
+            ]
+        };
     }
 
     private readonly Bindable<TernaryState> exTernaryState = new Bindable<TernaryState>();

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/HoldBody.cs
@@ -2,6 +2,7 @@
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Game.Rulesets.Objects.Drawables;
 using osuTK.Graphics;
 
@@ -11,6 +12,10 @@ public partial class HoldBody : CompositeDrawable
 {
     // This will be proxied, so a must.
     public override bool RemoveWhenNotAlive => false;
+
+    public override Quad ScreenSpaceDrawQuad => noteVisuals.ScreenSpaceDrawQuad;
+
+    private readonly LaneNoteVisual noteVisuals;
 
     public HoldBody()
     {
@@ -26,7 +31,7 @@ public partial class HoldBody : CompositeDrawable
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Child = new LaneNoteVisual
+                Child = noteVisuals = new LaneNoteVisual
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
@@ -40,8 +45,11 @@ public partial class HoldBody : CompositeDrawable
     private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
     [BackgroundDependencyLoader]
-    private void load(DrawableHitObject drawableObject)
+    private void load(DrawableHitObject? drawableObject)
     {
+        if (drawableObject is null)
+            return;
+
         accentColour.BindTo(drawableObject.AccentColour);
         accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideTapPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Slides/SlideTapPiece.cs
@@ -45,8 +45,11 @@ public partial class SlideTapPiece : CompositeDrawable
     private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
     [BackgroundDependencyLoader]
-    private void load(DrawableHitObject drawableObject)
+    private void load(DrawableHitObject? drawableObject)
     {
+        if (drawableObject is null)
+            return;
+
         accentColour.BindTo(drawableObject.AccentColour);
         accentColour.BindValueChanged(colour =>
         {

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapPiece.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/TapPiece.cs
@@ -31,8 +31,11 @@ public partial class TapPiece : CompositeDrawable
     private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
     [BackgroundDependencyLoader]
-    private void load(DrawableHitObject drawableObject)
+    private void load(DrawableHitObject? drawableObject)
     {
+        if (drawableObject is null)
+            return;
+
         accentColour.BindTo(drawableObject.AccentColour);
         accentColour.BindValueChanged(colour => Colour = colour.NewValue, true);
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchBody.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/Touches/TouchBody.cs
@@ -59,8 +59,11 @@ public partial class TouchBody : CompositeDrawable
     private readonly IBindable<Color4> accentColour = new Bindable<Color4>();
 
     [BackgroundDependencyLoader]
-    private void load(DrawableHitObject drawableObject)
+    private void load(DrawableHitObject? drawableObject)
     {
+        if (drawableObject is null)
+            return;
+
         accentColour.BindTo(drawableObject.AccentColour);
         accentColour.BindValueChanged(colour => PieceContainer.Colour = colour.NewValue, true);
     }

--- a/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/SentakkiHitObject.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Scoring;
 using osu.Game.Rulesets.Sentakki.Judgements;
@@ -15,7 +16,7 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Objects;
 
-public abstract class SentakkiHitObject : HitObject
+public abstract class SentakkiHitObject : HitObject, IHasDisplayColour
 {
     public int ScoreWeighting => Break ? 5 : BaseScoreWeighting;
 
@@ -35,12 +36,20 @@ public abstract class SentakkiHitObject : HitObject
 
     protected SentakkiHitObject()
     {
-        // We initialize the note colour to the default value first for test scenes
+        // We initialise the note colour to the default value first for test scenes
         // The colours during gameplay will be set during beatmap post-process
         colour.Value = DefaultNoteColour;
+
+        // The timeline blueprint uses this to set the display colour.
+        // Because the timeline blueprint only represents the top level object
+        // We can't apply any special colours related to those properties
+        DisplayColour.Value = DefaultNoteColour;
     }
 
     public override Judgement CreateJudgement() => new SentakkiJudgement();
+
+    [JsonIgnore]
+    public Bindable<Color4> DisplayColour { get; } = new Bindable<Color4>();
 
     private HitObjectProperty<Color4> colour;
 

--- a/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/Slide.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Newtonsoft.Json;
 using osu.Game.Rulesets.Judgements;
@@ -33,17 +34,31 @@ public class Slide : SentakkiLanedHitObject, IHasDuration
 
     protected override bool PlaysBreakSample => false;
 
+    /// <summary>
+    /// The duration of this slide, determined by the longest slide body in the list.
+    /// </summary>
+    /// <remarks>
+    /// If there are no slide bodies, this will return a duration of 0.
+    /// <br/>
+    /// When increasing/decreasing the duration, each slide body's duration will be scaled proportionally.
+    /// </remarks>
     public double Duration
     {
-        get
+        get => SlideInfoList.Select(static t => t.Duration).Prepend(0).Max();
+        set
         {
-            double max = 0;
-            for (int i = 0; i < SlideInfoList.Count; ++i)
-                max = Math.Max(max, SlideInfoList[i].Duration);
+            double max = SlideInfoList.Select(static t => t.Duration).Prepend(0).Max();
 
-            return max;
+            if (max == value)
+                return;
+
+            foreach (var s in SlideInfoList)
+            {
+                double ratio = s.Duration / max;
+
+                s.Duration = ratio * value;
+            }
         }
-        set => throw new NotSupportedException();
     }
 
     public TapTypeEnum TapType = TapTypeEnum.Star;

--- a/osu.Game.Rulesets.Sentakki/Objects/TouchHold.cs
+++ b/osu.Game.Rulesets.Sentakki/Objects/TouchHold.cs
@@ -15,6 +15,8 @@ namespace osu.Game.Rulesets.Sentakki.Objects;
 
 public partial class TouchHold : SentakkiHitObject, IHasDuration, IHasPosition
 {
+    public override Color4 DefaultNoteColour => DEFAULT_PALETTE[0];
+
     public double EndTime
     {
         get => StartTime + Duration;

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -18,6 +18,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Overlays.Settings;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
@@ -34,6 +35,7 @@ using osu.Game.Rulesets.Sentakki.Statistics;
 using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osuTK;
 using osuTK.Graphics;
@@ -52,6 +54,36 @@ public partial class SentakkiRuleset : Ruleset
     public override string Description => IsDevelopmentBuild ? "sentakki (Dev build)" : "sentakki";
     public override string PlayingVerb => "Washing laundry";
     public override string ShortName => "Sentakki";
+
+    #region Editor
+
+    public override bool EditorShowScrollSpeed => false;
+
+    public override HitObjectComposer? CreateHitObjectComposer()
+    {
+        return base.CreateHitObjectComposer();
+    }
+
+    public override IEnumerable<Drawable> CreateEditorSetupSections()
+    {
+        return
+        [
+            new MetadataSection(),
+            new FillFlowContainer
+            {
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(25),
+                Children =
+                [
+                    new ResourcesSection { RelativeSizeAxes = Axes.X },
+                    new DesignSection { RelativeSizeAxes = Axes.X },
+                ]
+            }
+        ];
+    }
+
+    #endregion
 
     public override IEnumerable<RulesetBeatmapAttribute> GetBeatmapAttributesForDisplay(IBeatmapInfo beatmapInfo, IReadOnlyCollection<Mod> mods) => [];
 

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -25,6 +25,7 @@ using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Sentakki.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Configuration;
 using osu.Game.Rulesets.Sentakki.Difficulty;
+using osu.Game.Rulesets.Sentakki.Edit;
 using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.Localisation;
 using osu.Game.Rulesets.Sentakki.Mods;
@@ -60,9 +61,7 @@ public partial class SentakkiRuleset : Ruleset
     public override bool EditorShowScrollSpeed => false;
 
     public override HitObjectComposer? CreateHitObjectComposer()
-    {
-        return base.CreateHitObjectComposer();
-    }
+        => new SentakkiHitObjectComposer(this);
 
     public override IEnumerable<Drawable> CreateEditorSetupSections()
     {


### PR DESCRIPTION
A part of a series that will supersede #220. This PR _does not_ aim to implement all the functionality of that PR, and only serves as a start to a more complete implementation.

## Background

The old PR was in perpetual draft status, partially due to me wanting a "complete" editor experience prior to releasing; but also because osu didn't support custom ruleset composers, and therefore just serves as another point of failure, while not being usable. This also meant that the editor branch have diverged, and keeping it updated to master became a chore.

I am doing yet another reimplementation, this time merging editor features piecemeal. By doing so I avoid the divergence problem, as there is no chance to accumulate that many changes within a single editor PR.

The sentakki composer will also be available to users in subsequent sentakki releases. This achieve 2 goals:
1. I get feedback from more people about the edit experience
2. I break the chicken-and-egg stalemate between osu! and the rulesets. 
    * Custom ruleset editors are considered low-priority in osu because of the lack of demand/implementations, while there is a lack of ruleset implementations/demand because of lack of osu support.