### PR TITLE
Implement sentakki editor specific inspector values

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -24,6 +24,8 @@ public partial class SentakkiHitObjectComposer : HitObjectComposer<SentakkiHitOb
 
     private DrawableRulesetDependencies dependencies = null!;
 
+    protected override Drawable CreateHitObjectInspector() => new SentakkiHitObjectInspector();
+
     protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         => dependencies = new DrawableRulesetDependencies(Ruleset, base.CreateChildDependencies(parent));
 

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
@@ -3,9 +3,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -41,7 +39,7 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
                 SentakkiHitObject selected = (SentakkiHitObject)objects.Single();
 
                 AddHeader("Type");
-                AddValue($"{selected.GetType().ReadableName()}");
+                addValue($"{selected.GetType().ReadableName()}");
 
                 addPositionInformation(selected);
 
@@ -49,7 +47,7 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
                 addSlideModifiersInformation(selected);
 
                 AddHeader("Time");
-                AddValue($"{selected.StartTime:#,0.##}ms");
+                addValue($"{selected.StartTime:#,0.##}ms");
 
                 addDurationInformation(selected);
 
@@ -65,12 +63,12 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
         switch (hitObject)
         {
             case IHasPosition pos:
-                AddValue($"x:{pos.X:#,0.##}");
-                AddValue($"y:{pos.Y:#,0.##}");
+                addValue($"x:{pos.X:#,0.##}");
+                addValue($"y:{pos.Y:#,0.##}");
                 break;
 
             case IHasLane lane:
-                AddValue($"Lane: {lane.Lane}");
+                addValue($"Lane: {lane.Lane}");
                 break;
         }
     }
@@ -84,11 +82,8 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
         double durationInBeats = duration.Duration / beatLength;
 
         AddHeader("Duration");
-
-        addValueWithSubvalue(
-                $"{duration.Duration:#,0.##}ms",
-                $"{durationInBeats:0.##} beats",
-                colourProvider.Content1);
+        addValue($"{duration.Duration:#,0.##}ms");
+        addValue($"{durationInBeats:0.##} beats");
 
         if (hitObject is not Slide s)
             return;
@@ -97,19 +92,12 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
         double movementDurationInBeats = s.SlideInfoList[0].EffectiveMovementDuration / beatLength;
 
         AddHeader("Wait duration");
-
-        addValueWithSubvalue(
-            $"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms",
-            $"{waitDurationInBeats:0.##} beats",
-            colourProvider.Content1
-        );
+        addValue($"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms");
+        addValue($"{waitDurationInBeats:0.##} beats");
 
         AddHeader("Movement duration");
-        addValueWithSubvalue(
-            $"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms",
-            $"{movementDurationInBeats:0.##} beats",
-            colourProvider.Content1
-        );
+        addValue($"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms");
+        addValue($"{movementDurationInBeats:0.##} beats");
     }
 
     private void addModifierInformation(SentakkiHitObject hitObject)
@@ -126,11 +114,11 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
 
         if (modifiers.Count == 0)
         {
-            AddValue("None");
+            addValue("None");
             return;
         }
 
-        AddValue(string.Join(", ", [.. modifiers]));
+        addValue(string.Join(", ", [.. modifiers]));
     }
 
     private void addSlideModifiersInformation(SentakkiHitObject hitObject)
@@ -150,11 +138,11 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
 
         if (modifiers.Count == 0)
         {
-            AddValue("None");
+            addValue("None");
             return;
         }
 
-        AddValue(string.Join(", ", [.. modifiers]));
+        addValue(string.Join(", ", [.. modifiers]));
     }
 
     private void addSlideSegmentInformation(SentakkiHitObject hitObject)
@@ -165,7 +153,7 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
         if (s.SlideInfoList.Count != 1)
         {
             AddHeader("Slide bodies");
-            AddValue($"{s.SlideInfoList.Count}");
+            addValue($"{s.SlideInfoList.Count}");
         }
 
         AddHeader("Segments");
@@ -190,35 +178,19 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
                     break;
             }
 
-            AddValue($"{segment.Shape}({simpleEndOffset}){mirrored}");
+            addValue($"{segment.Shape}({simpleEndOffset}){mirrored}");
         }
     }
 
-    private void addValueWithSubvalue(string value, string subvalue, Color4 colour, Color4? subvalueColour = null)
+    // This is an alternative implementation that reduces the spacing between the values and the headers
+    private void addValue(string value) => addValue(value, colourProvider.Content1);
+    private void addValue(string value, Color4 colour)
     {
-        InspectorText.AddParagraph("");
-
-        var wrappingContainer = new FillFlowContainer()
+        InspectorText.NewLine();
+        InspectorText.AddText(value, s =>
         {
-            AutoSizeAxes = Axes.Both,
-            Direction = FillDirection.Vertical,
-            Children = [
-                new OsuSpriteText()
-                {
-                    Text = value,
-                    Font = OsuFont.Torus.With(weight: FontWeight.SemiBold),
-                    Colour = colour,
-                },
-                new OsuSpriteText()
-                {
-                    Text = subvalue,
-                    Margin = new MarginPadding { Bottom = -5, },
-                    Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold),
-                    Colour = subvalueColour ?? colour,
-                }
-            ]
-        };
-
-        InspectorText.AddArbitraryDrawable(wrappingContainer);
+            s.Font = s.Font.With(weight: FontWeight.SemiBold);
+            s.Colour = colour;
+        });
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
@@ -213,7 +213,7 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
                 {
                     Text = subvalue,
                     Margin = new MarginPadding { Bottom = -5, },
-                    Font = OsuFont.Torus.With(size: 10, weight: FontWeight.SemiBold),
+                    Font = OsuFont.Torus.With(size: 12, weight: FontWeight.SemiBold),
                     Colour = subvalueColour ?? colour,
                 }
             ]

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
@@ -1,0 +1,102 @@
+using osu.Framework.Allocation;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Compose.Components;
+
+namespace osu.Game.Rulesets.Sentakki.Edit;
+
+public partial class SentakkiHitObjectInspector : HitObjectInspector
+{
+    [Resolved]
+    private EditorBeatmap editorBeatmap { get; set; } = null!;
+
+    protected override void AddInspectorValues(HitObject[] objects)
+    {
+        base.AddInspectorValues(objects);
+
+        if (objects.Length != 1)
+            return;
+
+        SentakkiHitObject hitObject = (SentakkiHitObject)objects[0];
+
+        if (hitObject is IHasDuration duration)
+        {
+            double beatLength = editorBeatmap.ControlPointInfo.TimingPointAt(hitObject.StartTime).BeatLength;
+            double durationInBeats = duration.Duration / beatLength;
+            AddValue($"{durationInBeats:0.##} beats");
+        }
+
+        {
+            if (hitObject is Slide s && s.SlideInfoList.Count == 1)
+            {
+                double beatLength = editorBeatmap.ControlPointInfo.TimingPointAt(hitObject.StartTime).BeatLength;
+                double waitDurationInBeats = s.SlideInfoList[0].EffectiveWaitDuration / beatLength;
+                double movementDurationInBeats = s.SlideInfoList[0].EffectiveMovementDuration / beatLength;
+
+                AddHeader("Wait duration");
+                AddValue($"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms");
+                AddValue($"{waitDurationInBeats:0.##} beats");
+
+                AddHeader("Movement duration");
+                AddValue($"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms");
+                AddValue($"{movementDurationInBeats:0.##} beats");
+            }
+        }
+
+        bool isBreak = hitObject.Break;
+        bool isEX = hitObject is not TouchHold && hitObject.Ex;
+
+        if (isBreak || isEX)
+        {
+            AddHeader("Modifiers");
+
+            if (isBreak)
+                AddValue("Break");
+
+            if (isEX)
+                AddValue($"EX");
+        }
+
+        {
+            if (hitObject is Slide s)
+            {
+                if (s.SlideInfoList.Count != 1)
+                {
+                    AddHeader("Slide bodies");
+                    AddValue($"{s.SlideInfoList.Count}");
+                }
+                else
+                {
+                    AddHeader("Segments");
+                    foreach (var segment in s.SlideInfoList[0].Segments)
+                    {
+                        int simpleEndOffset = segment.RelativeEndLane;
+                        if (simpleEndOffset > 4)
+                            simpleEndOffset -= 8;
+
+                        string mirrored = "";
+
+                        switch (segment.Shape)
+                        {
+                            case PathShape.Circle:
+                                mirrored = segment.Mirrored ? "CCW" : "CW";
+                                break;
+
+                            case PathShape.U:
+                            case PathShape.Cup:
+                            case PathShape.Thunder:
+                                mirrored = segment.Mirrored ? "M" : "";
+                                break;
+                        }
+
+                        AddValue($"{segment.Shape}({simpleEndOffset}){mirrored}");
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
@@ -114,7 +114,7 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
 
     private void addModifierInformation(SentakkiHitObject hitObject)
     {
-        AddHeader("Slide modifiers");
+        AddHeader("Modifiers");
 
         List<string> modifiers = [];
 

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
@@ -1,10 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+using osu.Game.Rulesets.Sentakki.Objects.Types;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Edit;
 
@@ -13,90 +23,206 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
     [Resolved]
     private EditorBeatmap editorBeatmap { get; set; } = null!;
 
+    [Resolved]
+    private OverlayColourProvider colourProvider { get; set; } = null!;
+
     protected override void AddInspectorValues(HitObject[] objects)
     {
-        base.AddInspectorValues(objects);
+        switch (objects.Length)
+        {
+            default:
+            case 0:
+                base.AddInspectorValues(objects);
+                break;
 
-        if (objects.Length != 1)
+            // This is an intentional reimplementation of the base behaviour.
+            // This is done to add the beat count to the durations.
+            case 1:
+                SentakkiHitObject selected = (SentakkiHitObject)objects.Single();
+
+                AddHeader("Type");
+                AddValue($"{selected.GetType().ReadableName()}");
+
+                addPositionInformation(selected);
+
+                addModifierInformation(selected);
+                addSlideModifiersInformation(selected);
+
+                AddHeader("Time");
+                AddValue($"{selected.StartTime:#,0.##}ms");
+
+                addDurationInformation(selected);
+
+                addSlideSegmentInformation(selected);
+                break;
+        }
+    }
+
+    private void addPositionInformation(SentakkiHitObject hitObject)
+    {
+        AddHeader("Position");
+
+        switch (hitObject)
+        {
+            case IHasPosition pos:
+                AddValue($"x:{pos.X:#,0.##}");
+                AddValue($"y:{pos.Y:#,0.##}");
+                break;
+
+            case IHasLane lane:
+                AddValue($"Lane: {lane.Lane}");
+                break;
+        }
+    }
+
+    private void addDurationInformation(SentakkiHitObject hitObject)
+    {
+        if (hitObject is not IHasDuration duration)
             return;
 
-        SentakkiHitObject hitObject = (SentakkiHitObject)objects[0];
+        double beatLength = editorBeatmap.ControlPointInfo.TimingPointAt(hitObject.StartTime).BeatLength;
+        double durationInBeats = duration.Duration / beatLength;
 
-        if (hitObject is IHasDuration duration)
+        AddHeader("Duration");
+
+        addValueWithSubvalue(
+                $"{duration.Duration:#,0.##}ms",
+                $"{durationInBeats:0.##} beats",
+                colourProvider.Content1);
+
+        if (hitObject is not Slide s)
+            return;
+
+        double waitDurationInBeats = s.SlideInfoList[0].EffectiveWaitDuration / beatLength;
+        double movementDurationInBeats = s.SlideInfoList[0].EffectiveMovementDuration / beatLength;
+
+        AddHeader("Wait duration");
+
+        addValueWithSubvalue(
+            $"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms",
+            $"{waitDurationInBeats:0.##} beats",
+            colourProvider.Content1
+        );
+
+        AddHeader("Movement duration");
+        addValueWithSubvalue(
+            $"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms",
+            $"{movementDurationInBeats:0.##} beats",
+            colourProvider.Content1
+        );
+    }
+
+    private void addModifierInformation(SentakkiHitObject hitObject)
+    {
+        AddHeader("Slide modifiers");
+
+        List<string> modifiers = [];
+
+        if (hitObject.Break)
+            modifiers.Add("Break");
+
+        if (hitObject.Ex)
+            modifiers.Add("Ex");
+
+        if (modifiers.Count == 0)
         {
-            double beatLength = editorBeatmap.ControlPointInfo.TimingPointAt(hitObject.StartTime).BeatLength;
-            double durationInBeats = duration.Duration / beatLength;
-            AddValue($"{durationInBeats:0.##} beats");
+            AddValue("None");
+            return;
         }
 
+        AddValue(string.Join(", ", [.. modifiers]));
+    }
+
+    private void addSlideModifiersInformation(SentakkiHitObject hitObject)
+    {
+        if (hitObject is not Slide s || s.SlideInfoList.Count != 1)
+            return;
+
+        AddHeader("Slide modifiers");
+
+        List<string> modifiers = [];
+
+        if (s.SlideInfoList[0].Break)
+            modifiers.Add("Break");
+
+        if (s.SlideInfoList[0].Ex)
+            modifiers.Add("Ex");
+
+        if (modifiers.Count == 0)
         {
-            if (hitObject is Slide s && s.SlideInfoList.Count == 1)
+            AddValue("None");
+            return;
+        }
+
+        AddValue(string.Join(", ", [.. modifiers]));
+    }
+
+    private void addSlideSegmentInformation(SentakkiHitObject hitObject)
+    {
+        if (hitObject is not Slide s)
+            return;
+
+        if (s.SlideInfoList.Count != 1)
+        {
+            AddHeader("Slide bodies");
+            AddValue($"{s.SlideInfoList.Count}");
+        }
+
+        AddHeader("Segments");
+        foreach (var segment in s.SlideInfoList[0].Segments)
+        {
+            int simpleEndOffset = segment.RelativeEndLane;
+            if (simpleEndOffset > 4)
+                simpleEndOffset -= 8;
+
+            string mirrored = "";
+
+            switch (segment.Shape)
             {
-                double beatLength = editorBeatmap.ControlPointInfo.TimingPointAt(hitObject.StartTime).BeatLength;
-                double waitDurationInBeats = s.SlideInfoList[0].EffectiveWaitDuration / beatLength;
-                double movementDurationInBeats = s.SlideInfoList[0].EffectiveMovementDuration / beatLength;
+                case PathShape.Circle:
+                    mirrored = segment.Mirrored ? "CCW" : "CW";
+                    break;
 
-                AddHeader("Wait duration");
-                AddValue($"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms");
-                AddValue($"{waitDurationInBeats:0.##} beats");
-
-                AddHeader("Movement duration");
-                AddValue($"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms");
-                AddValue($"{movementDurationInBeats:0.##} beats");
+                case PathShape.U:
+                case PathShape.Cup:
+                case PathShape.Thunder:
+                    mirrored = segment.Mirrored ? "M" : "";
+                    break;
             }
+
+            AddValue($"{segment.Shape}({simpleEndOffset}){mirrored}");
         }
+    }
 
-        bool isBreak = hitObject.Break;
-        bool isEX = hitObject is not TouchHold && hitObject.Ex;
+    private void addValueWithSubvalue(string value, string subvalue, Color4 colour, Color4? subvalueColour = null)
+    {
+        InspectorText.AddParagraph("");
 
-        if (isBreak || isEX)
+        var wrappingContainer = new FillFlowContainer()
         {
-            AddHeader("Modifiers");
-
-            if (isBreak)
-                AddValue("Break");
-
-            if (isEX)
-                AddValue($"EX");
-        }
-
-        {
-            if (hitObject is Slide s)
-            {
-                if (s.SlideInfoList.Count != 1)
+            AutoSizeAxes = Axes.Both,
+            Direction = FillDirection.Vertical,
+            Children = [
+                new OsuSpriteText()
                 {
-                    AddHeader("Slide bodies");
-                    AddValue($"{s.SlideInfoList.Count}");
-                }
-                else
+                    Text = value,
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                    Font = OsuFont.Torus.With(weight: FontWeight.SemiBold),
+                    Colour = colour,
+                },
+                new OsuSpriteText()
                 {
-                    AddHeader("Segments");
-                    foreach (var segment in s.SlideInfoList[0].Segments)
-                    {
-                        int simpleEndOffset = segment.RelativeEndLane;
-                        if (simpleEndOffset > 4)
-                            simpleEndOffset -= 8;
-
-                        string mirrored = "";
-
-                        switch (segment.Shape)
-                        {
-                            case PathShape.Circle:
-                                mirrored = segment.Mirrored ? "CCW" : "CW";
-                                break;
-
-                            case PathShape.U:
-                            case PathShape.Cup:
-                            case PathShape.Thunder:
-                                mirrored = segment.Mirrored ? "M" : "";
-                                break;
-                        }
-
-                        AddValue($"{segment.Shape}({simpleEndOffset}){mirrored}");
-                    }
+                    Text = subvalue,
+                    Origin = Anchor.TopRight,
+                    Anchor = Anchor.TopRight,
+                    Margin = new MarginPadding { Bottom = -5, },
+                    Font = OsuFont.Torus.With(size: 10, weight: FontWeight.SemiBold),
+                    Colour = subvalueColour ?? colour,
                 }
-            }
-        }
+            ]
+        };
 
+        InspectorText.AddArbitraryDrawable(wrappingContainer);
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectInspector.cs
@@ -206,16 +206,12 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
                 new OsuSpriteText()
                 {
                     Text = value,
-                    Anchor = Anchor.TopRight,
-                    Origin = Anchor.TopRight,
                     Font = OsuFont.Torus.With(weight: FontWeight.SemiBold),
                     Colour = colour,
                 },
                 new OsuSpriteText()
                 {
                     Text = subvalue,
-                    Origin = Anchor.TopRight,
-                    Anchor = Anchor.TopRight,
                     Margin = new MarginPadding { Bottom = -5, },
                     Font = OsuFont.Torus.With(size: 10, weight: FontWeight.SemiBold),
                     Colour = subvalueColour ?? colour,


### PR DESCRIPTION
|Laned notes| Touch notes|
|---|---|
|<img width="439" height="816" alt="image" src="https://github.com/user-attachments/assets/307bb4ac-e138-4f40-9996-3bb8f442512a" />|<img width="439" height="438" alt="image" src="https://github.com/user-attachments/assets/f491d7ec-575a-4f58-9fb3-2430c6b043a9" />|

Instead of directly using `base.AddInspectorValues(objects)` when there is a single object, I chose to basically copy and paste the implementation. This is done so I can re-order some things, and provide beat durations for the existing duration section.

Duration measured in beats is a more natural unit in certain aspects when mapping for sentakki, so that is provided. This is also provided for hitobject durations for consistency.