### PR TITLE
Fix HitObjectLine not connecting when they should

### DIFF
--- a/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/UI/Components/HitObjectLine/LineLifetimeEntry.cs
@@ -75,11 +75,11 @@ public class LineLifetimeEntry : LifetimeEntry
 
                 Colour = Color4.Gold;
 
-                int angleRange = delta == 4 ? 360 : 90 + 45 * delta;
+                int angleRange = delta >= 4 ? 360 : 90 + 45 * delta;
 
                 AngleRange = angleRange / 360f;
 
-                if (delta == 4)
+                if (delta >= 4)
                 {
                     Rotation = HitObjects.First().Lane.GetRotationForLane() - 180;
                 }


### PR DESCRIPTION
Closes #764 

Normally the line should be a full circle if the total distance is 4 lanes and above.