### PR TITLE
Implement slide segment popover in inspector

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideBodyHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideBodyHighlight.cs
@@ -1,3 +1,4 @@
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -69,13 +70,19 @@ public partial class SlideBodyHighlight : CompositeDrawable
 
     public override void Show()
     {
-        slideVisual.SlideBodyInfo = slideBodyInfo;
+        slideBodyInfo.Version.BindValueChanged(updateSlideVisual, true);
         base.Show();
     }
 
     public override void Hide()
     {
         base.Hide();
+        slideBodyInfo.Version.ValueChanged -= updateSlideVisual;
         slideVisual.SlideBodyInfo = null;
+    }
+
+    private void updateSlideVisual(ValueChangedEvent<int> _)
+    {
+        slideVisual.SlideBodyInfo = slideBodyInfo;
     }
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SelfUpdatingInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SelfUpdatingInspectorEntry.cs
@@ -1,0 +1,34 @@
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
+using osu.Framework.Threading;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Inspector;
+
+public partial class SelfUpdatingInspectorEntry : OsuSpriteText
+{
+    private Func<LocalisableString> textUpdateAction;
+
+    [Resolved]
+    private OverlayColourProvider colourProvider { get; set; } = null!;
+
+    public SelfUpdatingInspectorEntry(Func<LocalisableString> textUpdateAction)
+    {
+        this.textUpdateAction = textUpdateAction;
+        Font = Font.With(weight: FontWeight.SemiBold);
+        Text = textUpdateAction.Invoke();
+    }
+
+    private ScheduledDelegate? rollingTextUpdate;
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        Colour = colourProvider.Content1;
+        rollingTextUpdate ??= Scheduler.AddDelayed(() => Text = textUpdateAction.Invoke(), 250, true);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
@@ -8,15 +8,14 @@ using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Sentakki.Objects;
-using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
 using osu.Game.Rulesets.Sentakki.Objects.Types;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Sentakki.Edit;
+namespace osu.Game.Rulesets.Sentakki.Edit.Inspector;
 
-public partial class SentakkiHitObjectInspector : HitObjectInspector
+public partial class SentakkiHitObjectInspector : EditorInspector
 {
     [Resolved]
     private EditorBeatmap editorBeatmap { get; set; } = null!;
@@ -24,13 +23,42 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
     [Resolved]
     private OverlayColourProvider colourProvider { get; set; } = null!;
 
-    protected override void AddInspectorValues(HitObject[] objects)
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        EditorBeatmap.SelectedHitObjects.CollectionChanged += (_, _) => updateInspectorText();
+        EditorBeatmap.PlacementObject.BindValueChanged(_ => updateInspectorText());
+        EditorBeatmap.TransactionBegan += updateInspectorText;
+        EditorBeatmap.TransactionEnded += updateInspectorText;
+        updateInspectorText();
+    }
+
+
+    private void updateInspectorText()
+    {
+        InspectorText.Clear();
+
+        HitObject[] objects;
+
+        if (EditorBeatmap.SelectedHitObjects.Count > 0)
+            objects = EditorBeatmap.SelectedHitObjects.ToArray();
+        else if (EditorBeatmap.PlacementObject.Value != null)
+            objects = [EditorBeatmap.PlacementObject.Value];
+        else
+            objects = [];
+
+        AddInspectorValues(objects);
+    }
+
+
+    protected void AddInspectorValues(HitObject[] objects)
     {
         switch (objects.Length)
         {
             default:
             case 0:
-                base.AddInspectorValues(objects);
+                AddValue("No selection");
                 break;
 
             // This is an intentional reimplementation of the base behaviour.
@@ -159,28 +187,11 @@ public partial class SentakkiHitObjectInspector : HitObjectInspector
         AddHeader("Segments");
         foreach (var segment in s.SlideInfoList[0].Segments)
         {
-            int simpleEndOffset = segment.RelativeEndLane;
-            if (simpleEndOffset > 4)
-                simpleEndOffset -= 8;
-
-            string mirrored = "";
-
-            switch (segment.Shape)
-            {
-                case PathShape.Circle:
-                    mirrored = segment.Mirrored ? "CCW" : "CW";
-                    break;
-
-                case PathShape.U:
-                case PathShape.Cup:
-                case PathShape.Thunder:
-                    mirrored = segment.Mirrored ? "M" : "";
-                    break;
-            }
-
-            addValue($"{segment.Shape}({simpleEndOffset}){mirrored}");
+            InspectorText.NewLine();
+            InspectorText.AddArbitraryDrawable(new SentakkiSlideSegmentInspectorEntry(s.SlideInfoList[0], segment));
         }
     }
+
 
     // This is an alternative implementation that reduces the spacing between the values and the headers
     private void addValue(string value) => addValue(value, colourProvider.Content1);

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
@@ -13,7 +13,6 @@ using osu.Game.Rulesets.Sentakki.Edit.Inspector.Slides;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Types;
 using osu.Game.Screens.Edit;
-using osu.Game.Screens.Edit.Compose.Components;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Inspector;

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
@@ -185,10 +185,10 @@ public partial class SentakkiHitObjectInspector : EditorInspector
         }
 
         AddHeader("Segments");
-        foreach (var segment in s.SlideInfoList[0].Segments)
+        for (int i = 0; i < s.SlideInfoList[0].Segments.Count; ++i)
         {
             InspectorText.NewLine();
-            InspectorText.AddArbitraryDrawable(new SentakkiSlideSegmentInspectorEntry(s.SlideInfoList[0], segment));
+            InspectorText.AddArbitraryDrawable(new SentakkiSlideSegmentInspectorEntry(s, s.SlideInfoList[0], i));
         }
     }
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
@@ -51,7 +51,6 @@ public partial class SentakkiHitObjectInspector : CompositeDrawable
         updateInspectorText();
     }
 
-
     private void updateInspectorText()
     {
         inspectorText.Clear();
@@ -67,7 +66,6 @@ public partial class SentakkiHitObjectInspector : CompositeDrawable
 
         addInspectorValues(objects);
     }
-
 
     private void addInspectorValues(HitObject[] objects)
     {

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
@@ -7,6 +7,7 @@ using osu.Game.Graphics;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Sentakki.Edit.Inspector.Slides;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Types;
 using osu.Game.Screens.Edit;
@@ -185,11 +186,8 @@ public partial class SentakkiHitObjectInspector : EditorInspector
         }
 
         AddHeader("Segments");
-        for (int i = 0; i < s.SlideInfoList[0].Segments.Count; ++i)
-        {
-            InspectorText.NewLine();
-            InspectorText.AddArbitraryDrawable(new SentakkiSlideSegmentInspectorEntry(s, s.SlideInfoList[0], i));
-        }
+        InspectorText.NewLine();
+        InspectorText.AddArbitraryDrawable(new SlideBodyInspectorSection(s, s.SlideInfoList[0]));
     }
 
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiHitObjectInspector.cs
@@ -3,7 +3,9 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -16,50 +18,64 @@ using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Inspector;
 
-public partial class SentakkiHitObjectInspector : EditorInspector
+public partial class SentakkiHitObjectInspector : CompositeDrawable
 {
+    protected OsuTextFlowContainer inspectorText = null!;
+
     [Resolved]
     private EditorBeatmap editorBeatmap { get; set; } = null!;
 
     [Resolved]
     private OverlayColourProvider colourProvider { get; set; } = null!;
 
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        AutoSizeAxes = Axes.Y;
+        RelativeSizeAxes = Axes.X;
+
+        InternalChild = inspectorText = new OsuTextFlowContainer
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+        };
+    }
+
     protected override void LoadComplete()
     {
         base.LoadComplete();
 
-        EditorBeatmap.SelectedHitObjects.CollectionChanged += (_, _) => updateInspectorText();
-        EditorBeatmap.PlacementObject.BindValueChanged(_ => updateInspectorText());
-        EditorBeatmap.TransactionBegan += updateInspectorText;
-        EditorBeatmap.TransactionEnded += updateInspectorText;
+        editorBeatmap.SelectedHitObjects.CollectionChanged += (_, _) => updateInspectorText();
+        editorBeatmap.PlacementObject.BindValueChanged(_ => updateInspectorText());
+        editorBeatmap.TransactionBegan += updateInspectorText;
+        editorBeatmap.TransactionEnded += updateInspectorText;
         updateInspectorText();
     }
 
 
     private void updateInspectorText()
     {
-        InspectorText.Clear();
+        inspectorText.Clear();
 
         HitObject[] objects;
 
-        if (EditorBeatmap.SelectedHitObjects.Count > 0)
-            objects = EditorBeatmap.SelectedHitObjects.ToArray();
-        else if (EditorBeatmap.PlacementObject.Value != null)
-            objects = [EditorBeatmap.PlacementObject.Value];
+        if (editorBeatmap.SelectedHitObjects.Count > 0)
+            objects = [.. editorBeatmap.SelectedHitObjects];
+        else if (editorBeatmap.PlacementObject.Value != null)
+            objects = [editorBeatmap.PlacementObject.Value];
         else
             objects = [];
 
-        AddInspectorValues(objects);
+        addInspectorValues(objects);
     }
 
 
-    protected void AddInspectorValues(HitObject[] objects)
+    private void addInspectorValues(HitObject[] objects)
     {
         switch (objects.Length)
         {
-            default:
             case 0:
-                AddValue("No selection");
+                addValue("No selection");
                 break;
 
             // This is an intentional reimplementation of the base behaviour.
@@ -67,7 +83,7 @@ public partial class SentakkiHitObjectInspector : EditorInspector
             case 1:
                 SentakkiHitObject selected = (SentakkiHitObject)objects.Single();
 
-                AddHeader("Type");
+                addHeader("Type");
                 addValue($"{selected.GetType().ReadableName()}");
 
                 addPositionInformation(selected);
@@ -75,19 +91,29 @@ public partial class SentakkiHitObjectInspector : EditorInspector
                 addModifierInformation(selected);
                 addSlideModifiersInformation(selected);
 
-                AddHeader("Time");
+                addHeader("Time");
                 addValue($"{selected.StartTime:#,0.##}ms");
-
                 addDurationInformation(selected);
 
                 addSlideSegmentInformation(selected);
+                break;
+
+            default:
+                addHeader("Selected Objects");
+                addValue($"{objects.Length:#,0.##}");
+
+                addHeader("Start Time");
+                addValue($"{objects.Min(o => o.StartTime):#,0.##}ms");
+
+                addHeader("End Time");
+                addValue(new SelfUpdatingInspectorEntry(() => $"{objects.Max(o => o.GetEndTime()):#,0.##}ms"));
                 break;
         }
     }
 
     private void addPositionInformation(SentakkiHitObject hitObject)
     {
-        AddHeader("Position");
+        addHeader("Position");
 
         switch (hitObject)
         {
@@ -110,9 +136,9 @@ public partial class SentakkiHitObjectInspector : EditorInspector
         double beatLength = editorBeatmap.ControlPointInfo.TimingPointAt(hitObject.StartTime).BeatLength;
         double durationInBeats = duration.Duration / beatLength;
 
-        AddHeader("Duration");
-        addValue($"{duration.Duration:#,0.##}ms");
-        addValue($"{durationInBeats:0.##} beats");
+        addHeader("Duration");
+        addValue(new SelfUpdatingInspectorEntry(() => $"{duration.Duration:#,0.##}ms"));
+        addValue(new SelfUpdatingInspectorEntry(() => $"{duration.Duration / beatLength:0.##} beats"));
 
         if (hitObject is not Slide s)
             return;
@@ -120,18 +146,18 @@ public partial class SentakkiHitObjectInspector : EditorInspector
         double waitDurationInBeats = s.SlideInfoList[0].EffectiveWaitDuration / beatLength;
         double movementDurationInBeats = s.SlideInfoList[0].EffectiveMovementDuration / beatLength;
 
-        AddHeader("Wait duration");
-        addValue($"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms");
-        addValue($"{waitDurationInBeats:0.##} beats");
+        addHeader("Wait duration");
+        addValue(new SelfUpdatingInspectorEntry(() => $"{s.SlideInfoList[0].EffectiveWaitDuration:#,0.##}ms"));
+        addValue(new SelfUpdatingInspectorEntry(() => $"{s.SlideInfoList[0].EffectiveWaitDuration / beatLength:0.##} beats"));
 
-        AddHeader("Movement duration");
-        addValue($"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms");
-        addValue($"{movementDurationInBeats:0.##} beats");
+        addHeader("Movement duration");
+        addValue(new SelfUpdatingInspectorEntry(() => $"{s.SlideInfoList[0].EffectiveMovementDuration:#,0.##}ms"));
+        addValue(new SelfUpdatingInspectorEntry(() => $"{s.SlideInfoList[0].EffectiveMovementDuration / beatLength:0.##} beats"));
     }
 
     private void addModifierInformation(SentakkiHitObject hitObject)
     {
-        AddHeader("Modifiers");
+        addHeader("Modifiers");
 
         List<string> modifiers = [];
 
@@ -155,7 +181,7 @@ public partial class SentakkiHitObjectInspector : EditorInspector
         if (hitObject is not Slide s || s.SlideInfoList.Count != 1)
             return;
 
-        AddHeader("Slide modifiers");
+        addHeader("Slide modifiers");
 
         List<string> modifiers = [];
 
@@ -181,22 +207,34 @@ public partial class SentakkiHitObjectInspector : EditorInspector
 
         if (s.SlideInfoList.Count != 1)
         {
-            AddHeader("Slide bodies");
+            addHeader("Slide bodies");
             addValue($"{s.SlideInfoList.Count}");
         }
 
-        AddHeader("Segments");
-        InspectorText.NewLine();
-        InspectorText.AddArbitraryDrawable(new SlideBodyInspectorSection(s, s.SlideInfoList[0]));
+        addHeader("Segments");
+        inspectorText.NewLine();
+        inspectorText.AddArbitraryDrawable(new SlideBodyInspectorSection(s, s.SlideInfoList[0]));
     }
 
+    private void addHeader(string header) => inspectorText.AddParagraph($"{header}: ", s =>
+    {
+        s.Padding = new MarginPadding { Top = 2 };
+        s.Font = s.Font.With(size: 12);
+        s.Colour = colourProvider.Content2;
+    });
+
+    private void addValue<T>(T value) where T : Drawable
+    {
+        inspectorText.NewLine();
+        inspectorText.AddArbitraryDrawable(value);
+    }
 
     // This is an alternative implementation that reduces the spacing between the values and the headers
     private void addValue(string value) => addValue(value, colourProvider.Content1);
     private void addValue(string value, Color4 colour)
     {
-        InspectorText.NewLine();
-        InspectorText.AddText(value, s =>
+        inspectorText.NewLine();
+        inspectorText.AddText(value, s =>
         {
             s.Font = s.Font.With(weight: FontWeight.SemiBold);
             s.Colour = colour;

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
@@ -124,42 +124,63 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
             Child = new FillFlowContainer
             {
                 Direction = FillDirection.Vertical,
-                Width = 220,
+                Width = 240,
                 AutoSizeAxes = Axes.Y,
                 Spacing = new Vector2(5),
                 Children = [
-                    new OsuSpriteText{
+                    new OsuSpriteText
+                    {
                         Text = "Edit segment",
                         Font = OsuFont.Style.Heading2
                     },
-                    shapeDropdown = new FormEnumDropdown<PathShape>(){
+                    shapeDropdown = new FormEnumDropdown<PathShape>()
+                    {
                         Caption = "Shape",
-                    },
-                    mirroredCheckbox = new FormCheckBox(){
-                        Caption = "Mirrored",
-                    },
-                    endLaneDropdown = new FormDropdown<int>(){
-                        Caption = "End Lane",
                     },
                     new GridContainer{
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
 
                         RowDimensions = [new Dimension(GridSizeMode.AutoSize)],
-                        ColumnDimensions = [new Dimension(GridSizeMode.Distributed), new Dimension(GridSizeMode.Absolute, 5), new Dimension(GridSizeMode.Distributed)],
-
-                        Content = new Drawable?[][]{
+                        ColumnDimensions = [new Dimension(GridSizeMode.Relative, 0.4f), new Dimension(GridSizeMode.Absolute, 5), new Dimension(GridSizeMode.Distributed)],
+                        Content = new Drawable?[][]
+                        {
                             [
-                                new RoundedButton(){
-                                    Text = "Duplicate",
-                                    RelativeSizeAxes = Axes.X,
-                                    Enabled = {Value = true}
+                                endLaneDropdown = new FormDropdown<int>()
+                                {
+                                    Caption = "End Lane",
                                 },
                                 null,
-                                new DangerousRoundedButton(){
+                                mirroredCheckbox = new FormCheckBox()
+                                {
+                                    Caption = "Mirrored",
+                                },
+                            ]
+                        }
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+
+                        RowDimensions = [new Dimension(GridSizeMode.AutoSize)],
+                        ColumnDimensions = [new Dimension(GridSizeMode.Distributed), new Dimension(GridSizeMode.Absolute, 5), new Dimension(GridSizeMode.Distributed)],
+
+                        Content = new Drawable?[][]
+                        {
+                            [
+                                new RoundedButton()
+                                {
+                                    Text = "Duplicate",
+                                    RelativeSizeAxes = Axes.X,
+                                    Enabled = { Value = true }
+                                },
+                                null,
+                                new DangerousRoundedButton()
+                                {
                                     Text = "Delete",
                                     RelativeSizeAxes = Axes.X,
-                                    Enabled = {Value = true}
+                                    Enabled = { Value = true }
                                 }
                             ]
                         }

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
@@ -1,0 +1,154 @@
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Inspector;
+
+public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHasPopover
+{
+    private OsuSpriteText text;
+
+    private SlideBodyInfo slideBodyInfo;
+    private SlideSegment segment;
+
+    public SentakkiSlideSegmentInspectorEntry(SlideBodyInfo slideBodyInfo, SlideSegment segment)
+    {
+        AutoSizeAxes = Axes.Both;
+        this.slideBodyInfo = slideBodyInfo;
+        this.segment = segment;
+
+        int simpleEndOffset = segment.RelativeEndLane;
+        if (simpleEndOffset > 4)
+            simpleEndOffset -= 8;
+
+        string mirrored = "";
+
+        switch (segment.Shape)
+        {
+            case PathShape.Circle:
+                mirrored = segment.Mirrored ? "CCW" : "CW";
+                break;
+
+            case PathShape.U:
+            case PathShape.Cup:
+            case PathShape.Thunder:
+                mirrored = segment.Mirrored ? "M" : "";
+                break;
+        }
+
+        InternalChildren = [
+            text = new OsuSpriteText{
+                Text = $"{segment.Shape}({simpleEndOffset}){mirrored}",
+            },
+        ];
+
+        text.Font = text.Font.With(weight: FontWeight.SemiBold);
+    }
+
+    private Bindable<Visibility> popoverVisibilityState = new();
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        popoverVisibilityState.BindValueChanged(v => Colour = v.NewValue == Visibility.Visible ? Color4.YellowGreen : Color4.White);
+    }
+
+
+    public Popover? GetPopover() => new SegmentEditPopover(slideBodyInfo, segment)
+    {
+        State = { BindTarget = popoverVisibilityState }
+    };
+
+    protected override bool OnClick(ClickEvent e)
+    {
+        popoverVisibilityState.Value = Visibility.Visible;
+        this.ShowPopover();
+        return true;
+    }
+
+    private partial class SegmentEditPopover : OsuPopover
+    {
+        private SlideBodyInfo slideBodyInfo;
+        private SlideSegment segment;
+
+        public SegmentEditPopover(SlideBodyInfo slideBodyInfo, in SlideSegment segment)
+        {
+            this.slideBodyInfo = slideBodyInfo;
+            this.segment = segment;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                Width = 220,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(5),
+                Children = [
+                    new OsuSpriteText{
+                        Text = "Edit segment",
+                        Font = OsuFont.Style.Heading2
+                    },
+                    new FormEnumDropdown<PathShape>(){
+                        Caption = "Segment shape",
+                        Current = {Value = segment.Shape}
+                    },
+                    new FormCheckBox(){
+                        Caption = "Mirror shape",
+                        Current = {Value = segment.Mirrored}
+                    },
+                    new FormDropdown<int>(){
+                        Caption = "End offset",
+                        Items = Enumerable.Range(-3,8).Where(i => SlidePaths.CheckSlideValidity(segment with {RelativeEndLane = i.NormalizeLane()})),
+
+                        Current = {
+                            Value= Enumerable.Range(-3,8).First(i => i.NormalizeLane() == segment.RelativeEndLane)
+                        }
+                    },
+                    new GridContainer{
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+
+                        RowDimensions = [new Dimension(GridSizeMode.AutoSize)],
+                        ColumnDimensions = [new Dimension(GridSizeMode.Distributed), new Dimension(GridSizeMode.Absolute, 5), new Dimension(GridSizeMode.Distributed)],
+
+                        Content = new Drawable?[][]{
+                            [
+                                new RoundedButton(){
+                                    Text = "Duplicate",
+                                    RelativeSizeAxes = Axes.X,
+                                    Enabled = {Value = true}
+                                },
+                                null,
+                                new DangerousRoundedButton(){
+                                    Text = "Delete",
+                                    RelativeSizeAxes = Axes.X,
+                                    Enabled = {Value = true}
+                                }
+                            ]
+                        }
+                    }
+
+                ]
+            };
+        }
+    }
+
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -12,7 +13,9 @@ using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Sentakki.Extensions;
+using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Graphics;
 
@@ -23,13 +26,18 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
     private OsuSpriteText text;
 
     private SlideBodyInfo slideBodyInfo;
-    private SlideSegment segment;
+    private int segmentIndex;
 
-    public SentakkiSlideSegmentInspectorEntry(SlideBodyInfo slideBodyInfo, SlideSegment segment)
+    private SlideSegment segment => slideBodyInfo.Segments[segmentIndex];
+    private Slide slide;
+
+    public SentakkiSlideSegmentInspectorEntry(Slide slide, SlideBodyInfo slideBodyInfo, int index)
     {
-        AutoSizeAxes = Axes.Both;
+        this.slide = slide;
         this.slideBodyInfo = slideBodyInfo;
-        this.segment = segment;
+        segmentIndex = index;
+
+        AutoSizeAxes = Axes.Both;
 
         int simpleEndOffset = segment.RelativeEndLane;
         if (simpleEndOffset > 4)
@@ -69,7 +77,7 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
     }
 
 
-    public Popover? GetPopover() => new SegmentEditPopover(slideBodyInfo, segment)
+    public Popover? GetPopover() => new SegmentEditPopover(slide, slideBodyInfo, segmentIndex)
     {
         State = { BindTarget = popoverVisibilityState }
     };
@@ -83,14 +91,29 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
 
     private partial class SegmentEditPopover : OsuPopover
     {
-        private SlideBodyInfo slideBodyInfo;
-        private SlideSegment segment;
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
 
-        public SegmentEditPopover(SlideBodyInfo slideBodyInfo, in SlideSegment segment)
+        private Slide slide;
+        private SlideBodyInfo slideBodyInfo;
+        private int segmentIndex;
+
+        private SlideSegment segment => slideBodyInfo.Segments[segmentIndex];
+
+        private IBindable<int> versionBindable;
+
+        public SegmentEditPopover(Slide slide, SlideBodyInfo slideBodyInfo, int index)
         {
+            this.slide = slide;
             this.slideBodyInfo = slideBodyInfo;
-            this.segment = segment;
+            segmentIndex = index;
+
+            versionBindable = slideBodyInfo.Version.GetBoundCopy();
         }
+
+        private FormEnumDropdown<PathShape> shapeDropdown = null!;
+        private FormCheckBox mirroredCheckbox = null!;
+        private FormDropdown<int> endLaneDropdown = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -106,21 +129,14 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                         Text = "Edit segment",
                         Font = OsuFont.Style.Heading2
                     },
-                    new FormEnumDropdown<PathShape>(){
+                    shapeDropdown = new FormEnumDropdown<PathShape>(){
                         Caption = "Segment shape",
-                        Current = {Value = segment.Shape}
                     },
-                    new FormCheckBox(){
+                    mirroredCheckbox = new FormCheckBox(){
                         Caption = "Mirror shape",
-                        Current = {Value = segment.Mirrored}
                     },
-                    new FormDropdown<int>(){
-                        Caption = "End offset",
-                        Items = Enumerable.Range(-3,8).Where(i => SlidePaths.CheckSlideValidity(segment with {RelativeEndLane = i.NormalizeLane()})),
-
-                        Current = {
-                            Value= Enumerable.Range(-3,8).First(i => i.NormalizeLane() == segment.RelativeEndLane)
-                        }
+                    endLaneDropdown = new FormDropdown<int>(){
+                        Caption = "End Lane",
                     },
                     new GridContainer{
                         RelativeSizeAxes = Axes.X,
@@ -145,10 +161,69 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                             ]
                         }
                     }
-
                 ]
             };
+
+            versionBindable.BindValueChanged(v => refreshForms(), true);
+            shapeDropdown.Current.BindValueChanged(_ => updateShape());
+            mirroredCheckbox.Current.BindValueChanged(_ => updateShape());
+            endLaneDropdown.Current.BindValueChanged(_ => updateShape());
+        }
+
+        private void refreshForms()
+        {
+            if (slideBodyInfo.Segments.Count <= segmentIndex)
+                return;
+
+            shapeDropdown.Current.Value = segment.Shape;
+            mirroredCheckbox.Current.Value = segment.Mirrored;
+
+            int currentEndLane = (slide.Lane + slideBodyInfo.Segments.Take(segmentIndex + 1).Sum(s => s.RelativeEndLane)).NormalizeLane();
+            int startLane = (currentEndLane - segment.RelativeEndLane).NormalizeLane();
+
+            // We have to temporarily re-enable the bindable to be able to change it.
+            endLaneDropdown.Current.Disabled = false;
+
+            endLaneDropdown.Items = Enumerable.Range(0, 8).Where(i => SlidePaths.CheckSlideValidity(segment with { RelativeEndLane = i })).Select(i => (i + startLane).NormalizeLane() + 1).Order();
+            endLaneDropdown.Current.Value = currentEndLane + 1;
+            endLaneDropdown.Current.Disabled = endLaneDropdown.Items.Count() == 1;
+        }
+
+        private void updateShape()
+        {
+            List<SlideSegment> updatedSegments = [.. slideBodyInfo.Segments];
+
+            int currentEndLane = (slide.Lane + slideBodyInfo.Segments.Take(segmentIndex + 1).Sum(s => s.RelativeEndLane)).NormalizeLane();
+            int startLane = (currentEndLane - segment.RelativeEndLane).NormalizeLane();
+
+            int relativeEnd = (endLaneDropdown.Current.Value - 1 - startLane).NormalizeLane();
+
+            var candidateSegment = new SlideSegment
+            {
+                Shape = shapeDropdown.Current.Value,
+                Mirrored = mirroredCheckbox.Current.Value,
+                RelativeEndLane = relativeEnd
+            };
+
+            int offset = 1;
+            while (!SlidePaths.CheckSlideValidity(candidateSegment))
+            {
+                candidateSegment.RelativeEndLane = (relativeEnd + offset).NormalizeLane();
+                if (SlidePaths.CheckSlideValidity(candidateSegment))
+                    break;
+
+                candidateSegment.RelativeEndLane = (relativeEnd + offset).NormalizeLane();
+                if (SlidePaths.CheckSlideValidity(candidateSegment))
+                    break;
+
+                ++offset;
+            }
+
+            updatedSegments[segmentIndex] = candidateSegment;
+
+            slideBodyInfo.Segments = updatedSegments;
+
+            editorBeatmap.Update(slide);
         }
     }
-
 }

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/SentakkiSlideSegmentInspectorEntry.cs
@@ -39,6 +39,12 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
 
         AutoSizeAxes = Axes.Both;
 
+        InternalChild = text = new OsuSpriteText();
+        text.Font = text.Font.With(weight: FontWeight.SemiBold);
+    }
+
+    private void updateText()
+    {
         int simpleEndOffset = segment.RelativeEndLane;
         if (simpleEndOffset > 4)
             simpleEndOffset -= 8;
@@ -58,21 +64,18 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                 break;
         }
 
-        InternalChildren = [
-            text = new OsuSpriteText{
-                Text = $"{segment.Shape}({simpleEndOffset}){mirrored}",
-            },
-        ];
-
-        text.Font = text.Font.With(weight: FontWeight.SemiBold);
+        text.Text = $"{segment.Shape}({simpleEndOffset}){mirrored}";
     }
 
     private Bindable<Visibility> popoverVisibilityState = new();
+    private IBindable<int> versionBindable = new Bindable<int>();
 
     protected override void LoadComplete()
     {
         base.LoadComplete();
 
+        versionBindable.BindTo(slideBodyInfo.Version);
+        versionBindable.BindValueChanged(_ => updateText(), true);
         popoverVisibilityState.BindValueChanged(v => Colour = v.NewValue == Visibility.Visible ? Color4.YellowGreen : Color4.White);
     }
 
@@ -130,10 +133,10 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                         Font = OsuFont.Style.Heading2
                     },
                     shapeDropdown = new FormEnumDropdown<PathShape>(){
-                        Caption = "Segment shape",
+                        Caption = "Shape",
                     },
                     mirroredCheckbox = new FormCheckBox(){
-                        Caption = "Mirror shape",
+                        Caption = "Mirrored",
                     },
                     endLaneDropdown = new FormDropdown<int>(){
                         Caption = "End Lane",

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideBodyInspectorSection.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideBodyInspectorSection.cs
@@ -37,6 +37,10 @@ public partial class SlideBodyInspectorSection : CompositeDrawable
 
     private void populateEntries()
     {
+        // The entries will update themselves when SlideBodyInfo changes
+        // This prevents the popup from closing automatically
+        // We only need to remove excess entries or add missing ones to match the current count.
+
         if (segmentEntries.Count >= slideBodyInfo.Segments.Count)
         {
             segmentEntries.RemoveRange([.. segmentEntries.Children.Skip(slideBodyInfo.Segments.Count)], true);

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideBodyInspectorSection.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideBodyInspectorSection.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.SlidePath;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Inspector.Slides;
+
+public partial class SlideBodyInspectorSection : CompositeDrawable
+{
+    protected FillFlowContainer segmentEntries = null!;
+
+    private IBindable<int> slideBodyVersion = new Bindable<int>();
+
+    private Slide slide;
+    private SlideBodyInfo slideBodyInfo;
+
+    public SlideBodyInspectorSection(Slide slide, SlideBodyInfo slideBodyInfo)
+    {
+        this.slide = slide;
+        this.slideBodyInfo = slideBodyInfo;
+
+        AutoSizeAxes = Axes.Y;
+        RelativeSizeAxes = Axes.X;
+
+        InternalChild = segmentEntries = new FillFlowContainer
+        {
+            AutoSizeAxes = Axes.Y,
+            RelativeSizeAxes = Axes.X,
+            Direction = FillDirection.Vertical
+        };
+
+        slideBodyVersion.BindTo(slideBodyInfo.Version);
+        slideBodyVersion.BindValueChanged(_ => populateEntries(), true);
+    }
+
+    private void populateEntries()
+    {
+        if (segmentEntries.Count >= slideBodyInfo.Segments.Count)
+        {
+            segmentEntries.RemoveRange([.. segmentEntries.Children.Skip(slideBodyInfo.Segments.Count)], true);
+            return;
+        }
+
+        for (int i = segmentEntries.Count; i < slideBodyInfo.Segments.Count; ++i)
+            segmentEntries.Add(new SentakkiSlideSegmentInspectorEntry(slide, slideBodyInfo, i));
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -87,7 +87,6 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
 
     protected override bool OnClick(ClickEvent e)
     {
-        popoverVisibilityState.Value = Visibility.Visible;
         this.ShowPopover();
         return true;
     }

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -82,7 +82,6 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
         popoverVisibilityState.BindValueChanged(v => Colour = v.NewValue == Visibility.Visible ? colours.YellowDark : Color4.White);
     }
 
-
     public Popover? GetPopover() => new SegmentEditPopover(slide, slideBodyInfo, segmentIndex)
     {
         State = { BindTarget = popoverVisibilityState }

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -23,6 +23,9 @@ namespace osu.Game.Rulesets.Sentakki.Edit.Inspector.Slides;
 
 public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHasPopover
 {
+    [Resolved]
+    private OsuColour colours { get; set; } = null!;
+
     private OsuSpriteText text;
 
     private SlideBodyInfo slideBodyInfo;
@@ -76,7 +79,7 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
 
         versionBindable.BindTo(slideBodyInfo.Version);
         versionBindable.BindValueChanged(_ => updateText(), true);
-        popoverVisibilityState.BindValueChanged(v => Colour = v.NewValue == Visibility.Visible ? Color4.YellowGreen : Color4.White);
+        popoverVisibilityState.BindValueChanged(v => Colour = v.NewValue == Visibility.Visible ? colours.YellowDark : Color4.White);
     }
 
 
@@ -89,6 +92,25 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
     {
         this.ShowPopover();
         return true;
+    }
+
+    protected override bool OnHover(HoverEvent e)
+    {
+        if (popoverVisibilityState.Value is Visibility.Visible)
+            return false;
+
+        Colour = colours.YellowLight;
+
+        return true;
+    }
+
+    protected override void OnHoverLost(HoverLostEvent e)
+    {
+        if (popoverVisibilityState.Value is Visibility.Visible)
+            return;
+
+        Colour = Color4.White;
+        base.OnHoverLost(e);
     }
 
     private partial class SegmentEditPopover : OsuPopover
@@ -264,6 +286,7 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
         private void duplicateSegment()
         {
             List<SlideSegment> updatedSegments = [.. slideBodyInfo.Segments];
+
             updatedSegments.Insert(segmentIndex, segment);
 
             slideBodyInfo.Segments = updatedSegments;

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -156,31 +156,30 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                         Text = "Edit segment",
                         Font = OsuFont.Style.Heading2
                     },
-                    shapeDropdown = new FormEnumDropdown<PathShape>()
-                    {
-                        Caption = "Shape",
-                    },
                     new GridContainer
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-
                         RowDimensions = [new Dimension(GridSizeMode.AutoSize)],
-                        ColumnDimensions = [new Dimension(GridSizeMode.Relative, 0.4f), new Dimension(GridSizeMode.Absolute, 5), new Dimension(GridSizeMode.Distributed)],
+                        ColumnDimensions = [new Dimension(GridSizeMode.Distributed), new Dimension(GridSizeMode.Absolute, 5), new Dimension(GridSizeMode.Distributed)],
                         Content = new Drawable?[][]
                         {
                             [
+                                shapeDropdown = new FormEnumDropdown<PathShape>()
+                                {
+                                    Caption = "Shape",
+                                },
+                                null,
                                 endLaneDropdown = new FormDropdown<int>()
                                 {
                                     Caption = "End Lane",
                                 },
-                                null,
-                                mirroredCheckbox = new FormCheckBox()
-                                {
-                                    Caption = "Mirrored",
-                                },
                             ]
                         }
+                    },
+                    mirroredCheckbox = new FormCheckBox()
+                    {
+                        Caption = "Mirrored",
                     },
                     new GridContainer
                     {

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -19,7 +19,7 @@ using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Sentakki.Edit.Inspector;
+namespace osu.Game.Rulesets.Sentakki.Edit.Inspector.Slides;
 
 public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHasPopover
 {
@@ -118,6 +118,8 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
         private FormCheckBox mirroredCheckbox = null!;
         private FormDropdown<int> endLaneDropdown = null!;
 
+        private RoundedButton deleteButton = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -173,14 +175,16 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                                 {
                                     Text = "Duplicate",
                                     RelativeSizeAxes = Axes.X,
-                                    Enabled = { Value = true }
+                                    Enabled = { Value = true },
+                                    Action = duplicateSegment
                                 },
                                 null,
-                                new DangerousRoundedButton()
+                                deleteButton = new DangerousRoundedButton()
                                 {
                                     Text = "Delete",
                                     RelativeSizeAxes = Axes.X,
-                                    Enabled = { Value = true }
+                                    Enabled = { Value = true },
+                                    Action = deleteSegment
                                 }
                             ]
                         }
@@ -211,6 +215,8 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
             endLaneDropdown.Items = Enumerable.Range(0, 8).Where(i => SlidePaths.CheckSlideValidity(segment with { RelativeEndLane = i })).Select(i => (i + startLane).NormalizeLane() + 1).Order();
             endLaneDropdown.Current.Value = currentEndLane + 1;
             endLaneDropdown.Current.Disabled = endLaneDropdown.Items.Count() == 1;
+
+            deleteButton.Enabled.Value = slideBodyInfo.Segments.Count > 1;
         }
 
         private void updateShape()
@@ -246,7 +252,21 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
             updatedSegments[segmentIndex] = candidateSegment;
 
             slideBodyInfo.Segments = updatedSegments;
+            editorBeatmap.Update(slide);
+        }
 
+        private void deleteSegment()
+        {
+            slideBodyInfo.Segments = [.. slideBodyInfo.Segments.Where((v, i) => i != segmentIndex)];
+            editorBeatmap.Update(slide);
+        }
+
+        private void duplicateSegment()
+        {
+            List<SlideSegment> updatedSegments = [.. slideBodyInfo.Segments];
+            updatedSegments.Insert(segmentIndex, segment);
+
+            slideBodyInfo.Segments = updatedSegments;
             editorBeatmap.Update(slide);
         }
     }

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -242,7 +242,7 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                 if (SlidePaths.CheckSlideValidity(candidateSegment))
                     break;
 
-                candidateSegment.RelativeEndLane = (relativeEnd + offset).NormalizeLane();
+                candidateSegment.RelativeEndLane = (relativeEnd - offset).NormalizeLane();
                 if (SlidePaths.CheckSlideValidity(candidateSegment))
                     break;
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Inspector/Slides/SlideSegmentInspectorEntry.cs
@@ -138,7 +138,8 @@ public partial class SentakkiSlideSegmentInspectorEntry : CompositeDrawable, IHa
                     {
                         Caption = "Shape",
                     },
-                    new GridContainer{
+                    new GridContainer
+                    {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
 

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiHitObjectComposer.cs
@@ -10,6 +10,7 @@ using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Sentakki.Edit.CompositionTools;
+using osu.Game.Rulesets.Sentakki.Edit.Inspector;
 using osu.Game.Rulesets.Sentakki.Edit.Snapping;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.UI;


### PR DESCRIPTION
Provides a straightforward way to adjust segments quickly without fumbling with the playfield.

A custom inspector drawable was made to avoid the unconditional periodic refresh that makes the popover close itself.

[Screencast From 2026-02-22 15-47-50.webm](https://github.com/user-attachments/assets/bcc21228-9687-46fe-bd46-36c3e31f9415)
