### PR TITLE
Add mod icon for Experimental

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -2,10 +2,8 @@ using System;
 using System.ComponentModel;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -31,8 +29,6 @@ public class SentakkiModChallenge : ModFailCondition, IApplicableToDrawableRules
     public override bool RequiresConfiguration => true;
 
     public override double ScoreMultiplier => 1.00;
-
-    public override IconUsage? Icon => OsuIcon.Heart;
 
     public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModChallenge.cs
@@ -2,8 +2,10 @@ using System;
 using System.ComponentModel;
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
@@ -29,6 +31,9 @@ public class SentakkiModChallenge : ModFailCondition, IApplicableToDrawableRules
     public override bool RequiresConfiguration => true;
 
     public override double ScoreMultiplier => 1.00;
+
+    public override IconUsage? Icon => OsuIcon.Heart;
+
     public override bool Ranked => true;
 
     public override Type[] IncompatibleMods =>

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -1,7 +1,9 @@
 ﻿using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Sentakki.Beatmaps;
 using osu.Game.Rulesets.Sentakki.Beatmaps.Converter;
@@ -19,6 +21,8 @@ public class SentakkiModExperimental : Mod, IApplicableToBeatmapConverter
     public override bool RequiresConfiguration => true;
 
     public override double ScoreMultiplier => 1.00;
+
+    public override IconUsage? Icon => OsuIcon.CheckCircle;
 
     public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -22,7 +22,7 @@ public class SentakkiModExperimental : Mod, IApplicableToBeatmapConverter
 
     public override double ScoreMultiplier => 1.00;
 
-    public override IconUsage? Icon => OsuIcon.CheckCircle;
+    public override IconUsage? Icon => OsuIcon.Debug;
 
     public override bool Ranked => true;
 

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModNoTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModNoTouch.cs
@@ -1,5 +1,7 @@
 using System;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Localisation.Mods;
@@ -14,6 +16,7 @@ public class SentakkiModNoTouch : Mod, IApplicableToDrawableHitObject
     public override ModType Type => ModType.Automation;
     public override LocalisableString Description => SentakkiModNoTouchStrings.ModDescription;
     public override double ScoreMultiplier => .2f;
+    public override IconUsage? Icon => OsuIcon.ModNoRelease;
     public override Type[] IncompatibleMods => [.. base.IncompatibleMods, typeof(ModAutoplay)];
 
     public void ApplyToDrawableHitObject(DrawableHitObject drawableHitObject)

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModNoTouch.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModNoTouch.cs
@@ -1,7 +1,5 @@
 using System;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Sentakki.Localisation.Mods;
@@ -16,7 +14,6 @@ public class SentakkiModNoTouch : Mod, IApplicableToDrawableHitObject
     public override ModType Type => ModType.Automation;
     public override LocalisableString Description => SentakkiModNoTouchStrings.ModDescription;
     public override double ScoreMultiplier => .2f;
-    public override IconUsage? Icon => OsuIcon.ModNoRelease;
     public override Type[] IncompatibleMods => [.. base.IncompatibleMods, typeof(ModAutoplay)];
 
     public void ApplyToDrawableHitObject(DrawableHitObject drawableHitObject)


### PR DESCRIPTION
Added mod icons so they aren't just the mod acronyms now.

| Before | After |
|---|---|
| <img width="1106" height="357" alt="image" src="https://github.com/user-attachments/assets/80952bfa-2dac-48a4-a132-4a32b31a23a4" />  |  <img width="1090" height="307" alt="{D71C3811-0638-4242-ACC0-621826C11608}" src="https://github.com/user-attachments/assets/ce68aa54-b6c3-4566-8d14-375809ff565c" /> |

- Challenge: uses the `Heart` icon, also used by the favorite button
- No Touch: uses the `ModNoRelease` icon, used by (no way) the No Release mod from osu!mania. I think using this rather than `ModTouchDevice` is better to avoid repetition in icons, even if the No Touch and No Release mods to fully different things
- Experimental: uses the `Debug` icon. There wasn't realy a icon that felt very fitting for this mod (a 'potion' style icon would be perfect) but this is also a good choice I'd say