### PR TITLE
Fix 1-way incompatibility for AU, AS and AC

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAccuracyChallenge.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAccuracyChallenge.cs
@@ -5,5 +5,5 @@ namespace osu.Game.Rulesets.Sentakki.Mods;
 
 public class SentakkiModAccuracyChallenge : ModAccuracyChallenge
 {
-    public override Type[] IncompatibleMods => [.. base.IncompatibleMods, typeof(ModFailCondition)];
+    public override Type[] IncompatibleMods => [.. base.IncompatibleMods, typeof(ModFailCondition), typeof(ModAutoplay)];
 }

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModAutoplay.cs
@@ -20,7 +20,8 @@ public class SentakkiModAutoplay : ModAutoplay, IApplicableToDrawableHitObject
     [
         typeof(ModRelax),
         typeof(ModFailCondition),
-        typeof(SentakkiModNoTouch)
+        typeof(SentakkiModNoTouch),
+        typeof(ModAdaptiveSpeed),
     ];
 
     public void ApplyToDrawableHitObject(DrawableHitObject drawableHitObject)


### PR DESCRIPTION
AS blocked AU, but it didn't block back
AU blocked AC, but it didn't block back

....that or i accidentaly reversed how the blocks were done in my head while writing here. Either way this is now fixed as now, both of those do block back/are a 2-way block

This is just me blocking those back tho - I'm not even sure why AUAC is blocked but I'm not considering that here, I'm just fixing a broken 1-way.