### PR TITLE
Wrap slide offset updates in a transaction when using hotkeys

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideOffsetTool.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideOffsetTool.cs
@@ -114,7 +114,10 @@ public partial class SlideOffsetTool : CompositeDrawable
                 double beatLength = editorBeatmap.GetBeatLengthAtTime(editorClock.CurrentTime);
                 slideBodyInfo.WaitDuration = slideBodyInfo.EffectiveWaitDuration + beatLength;
 
+                editorBeatmap.BeginChange();
                 editorBeatmap.Update(slide);
+                editorBeatmap.EndChange();
+
                 return true;
             }
 
@@ -124,7 +127,9 @@ public partial class SlideOffsetTool : CompositeDrawable
                 double beatLength = editorBeatmap.GetBeatLengthAtTime(editorClock.CurrentTime);
                 slideBodyInfo.WaitDuration = slideBodyInfo.EffectiveWaitDuration - beatLength;
 
+                editorBeatmap.BeginChange();
                 editorBeatmap.Update(slide);
+                editorBeatmap.EndChange();
 
                 return true;
             }


### PR DESCRIPTION
This ensures that the inspector is immediately recreated, providing more instant feedback.

I chose not to wrap other cases in a transaction, since the effect is not quite as noticeable when your eyes are focusing on the cursor instead of the inspector.