### PR TITLE
Drop icon for `Experimental` mod

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -22,8 +22,6 @@ public class SentakkiModExperimental : Mod, IApplicableToBeatmapConverter
 
     public override double ScoreMultiplier => 1.00;
 
-    public override IconUsage? Icon => FontAwesome.Solid.Microchip;
-
     public override bool Ranked => true;
 
     [SettingSource(typeof(SentakkiModExperimentalStrings), nameof(SentakkiModExperimentalStrings.FanSlides), nameof(SentakkiModExperimentalStrings.FanSlidesDescription))]

--- a/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
+++ b/osu.Game.Rulesets.Sentakki/Mods/SentakkiModExperimental.cs
@@ -22,7 +22,7 @@ public class SentakkiModExperimental : Mod, IApplicableToBeatmapConverter
 
     public override double ScoreMultiplier => 1.00;
 
-    public override IconUsage? Icon => OsuIcon.Debug;
+    public override IconUsage? Icon => FontAwesome.Solid.Microchip;
 
     public override bool Ranked => true;
 


### PR DESCRIPTION
closes issue #801 

This can't really be fixed currently because there isn't a proper way to make ruleset-specific textures outside of gameplay. Using a workaround is not really a good option like at all.

Basically, not a Sen issue but a issue inside osu itself.

Tracking issue for that can be found [here](https://github.com/ppy/osu/issues/13587). Untill that is closed, its not really possible to make icons work correctly here.

