### PR TITLE
Fix slides having negative duration after pattern reverse

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -60,6 +60,7 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
                 times.Add(d.EndTime);
         }
 
+        times.Sort();
         times.Reverse();
 
         int i = 0;


### PR DESCRIPTION
The times are not ordered, causing the problem when calculating the duration.

Still broken as shit though, might disable in a future PR.