### PR TITLE
Disable reverse and rotate buttons

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -34,7 +34,7 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
         breakSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setBreakSlideState, v.NewValue);
     }
 
-    public override SelectionRotationHandler CreateRotationHandler() => new SentakkiRotationHandler();
+    // public override SelectionRotationHandler CreateRotationHandler() => new SentakkiRotationHandler();
 
     protected override void OnSelectionChanged()
     {
@@ -43,7 +43,7 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
         // We are always able to flip hitobjects
         SelectionBox.CanFlipX = true;
         SelectionBox.CanFlipY = true;
-        SelectionBox.CanReverse = SelectedItems.Count > 1;
+        // SelectionBox.CanReverse = SelectedItems.Count > 1;
     }
 
     public override bool HandleReverse()


### PR DESCRIPTION
Implementation remains in place, just inaccessible.

Reverse button is... not reliable and destructive.
Rotate buttons is... have limited usage, and shows unusable dumb shits.

Maybe revisit later down the line.