### PR TITLE
Add button to omit slide tap

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
@@ -69,11 +69,10 @@ public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide,
 
         Rotation = HitObject.Lane.GetRotationForLane();
 
-        slideTapHighlight.Scale = new Vector2(Math.Clamp(
-            Interpolation.ValueAt(HitObject.StartTime, 1f, 0f, editorClock.CurrentTime + (animationSpeed.Value / 2), editorClock.CurrentTime + animationSpeed.Value),
-            0f, 1f));
+        float targetScale = Interpolation.ValueAt(HitObject.StartTime, 1f, 0f, editorClock.CurrentTime + (animationSpeed.Value / 2), editorClock.CurrentTime + animationSpeed.Value);
+        targetScale = Math.Clamp(targetScale, 0, 1);
 
-        tapHighlight.Scale = slideTapHighlight.Scale;
+        tapHighlight.Scale = slideTapHighlight.Scale = new Vector2(targetScale);
 
         slideTapHighlight.Y = -Interpolation.ValueAt(
                 HitObject.StartTime,
@@ -86,25 +85,30 @@ public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide,
         slideTapHighlight.Y = Math.Clamp(slideTapHighlight.Y, -SentakkiPlayfield.INTERSECTDISTANCE, -SentakkiPlayfield.NOTESTARTDISTANCE);
         tapHighlight.Y = slideTapHighlight.Y;
 
-        if (Item.TapType is Slide.TapTypeEnum.None)
+        switch (Item.TapType)
         {
-            slideTapHighlight.Alpha = 0.5f;
-            tapHighlight.Alpha = 0;
-        }
-        else if (Item.TapType is Slide.TapTypeEnum.Tap)
-        {
-            slideTapHighlight.Alpha = 0f;
-            tapHighlight.Alpha = 1;
-        }
-        else
-        {
-            SlideTapPiece tapVisual = (SlideTapPiece)DrawableObject.SlideTaps.Child.TapVisual;
+            case Slide.TapTypeEnum.None:
+                slideTapHighlight.Alpha = 0.5f;
+                tapHighlight.Alpha = 0;
+                slideTapHighlight.Stars.Rotation = 0;
+                slideTapHighlight.SecondStar.Alpha = 0;
+                break;
 
-            slideTapHighlight.Stars.Rotation = tapVisual.Stars.Rotation;
-            slideTapHighlight.SecondStar.Alpha = tapVisual.SecondStar.Alpha;
+            // While there is no way to manually make this in the editor, it could still appear due to converts/imports.
+            case Slide.TapTypeEnum.Tap:
+                slideTapHighlight.Alpha = 0f;
+                tapHighlight.Alpha = 1;
+                break;
 
-            slideTapHighlight.Alpha = 1f;
-            tapHighlight.Alpha = 0;
+            default:
+                SlideTapPiece tapVisual = (SlideTapPiece)DrawableObject.SlideTaps.Child.TapVisual;
+
+                slideTapHighlight.Stars.Rotation = tapVisual.Stars.Rotation;
+                slideTapHighlight.SecondStar.Alpha = tapVisual.SecondStar.Alpha;
+
+                slideTapHighlight.Alpha = 1f;
+                tapHighlight.Alpha = 0;
+                break;
         }
 
         if (slideBodyHighlight is null)

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSelectionBlueprint.cs
@@ -1,11 +1,19 @@
 
+using System;
 using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables;
+using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces;
 using osu.Game.Rulesets.Sentakki.Objects.Drawables.Pieces.Slides;
+using osu.Game.Rulesets.Sentakki.UI;
+using osu.Game.Screens.Edit;
 using osuTK;
 using osuTK.Graphics;
 
@@ -15,6 +23,7 @@ public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide,
 {
     private readonly SlideBodyHighlight? slideBodyHighlight;
     private readonly SlideTapPiece slideTapHighlight;
+    private readonly TapPiece tapHighlight;
 
     public override Quad SelectionQuad => slideTapHighlight.ScreenSpaceDrawQuad;
     public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
@@ -29,7 +38,29 @@ public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide,
         if (item.SlideInfoList.Count == 1)
             AddInternal(slideBodyHighlight = new SlideBodyHighlight(item, item.SlideInfoList[0]) { });
 
-        AddInternal(slideTapHighlight = new SlideTapPiece { Colour = Color4.YellowGreen });
+        AddInternal(
+            new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Colour = Color4.YellowGreen,
+                Children = [
+                    slideTapHighlight = new SlideTapPiece(),
+                    tapHighlight = new TapPiece()
+                ]
+            }
+        );
+    }
+
+    [Resolved]
+    private EditorClock editorClock { get; set; } = null!;
+
+    private readonly Bindable<double> animationSpeed = new Bindable<double>(5);
+
+    [BackgroundDependencyLoader]
+    private void load(SentakkiBlueprintContainer blueprintContainer)
+    {
+        animationSpeed.BindTo(blueprintContainer.Composer.DrawableRuleset.AdjustedAnimDuration);
     }
 
     protected override void Update()
@@ -38,12 +69,43 @@ public partial class SlideSelectionBlueprint : SentakkiSelectionBlueprint<Slide,
 
         Rotation = HitObject.Lane.GetRotationForLane();
 
-        SlideTapPiece tapVisual = (SlideTapPiece)DrawableObject.SlideTaps.Child.TapVisual;
+        slideTapHighlight.Scale = new Vector2(Math.Clamp(
+            Interpolation.ValueAt(HitObject.StartTime, 1f, 0f, editorClock.CurrentTime + (animationSpeed.Value / 2), editorClock.CurrentTime + animationSpeed.Value),
+            0f, 1f));
 
-        slideTapHighlight.Stars.Rotation = tapVisual.Stars.Rotation;
-        slideTapHighlight.SecondStar.Alpha = tapVisual.SecondStar.Alpha;
-        slideTapHighlight.Scale = tapVisual.Scale;
-        slideTapHighlight.Y = tapVisual.Y;
+        tapHighlight.Scale = slideTapHighlight.Scale;
+
+        slideTapHighlight.Y = -Interpolation.ValueAt(
+                HitObject.StartTime,
+                SentakkiPlayfield.INTERSECTDISTANCE,
+                SentakkiPlayfield.NOTESTARTDISTANCE,
+                editorClock.CurrentTime,
+                editorClock.CurrentTime + (animationSpeed.Value / 2)
+            );
+
+        slideTapHighlight.Y = Math.Clamp(slideTapHighlight.Y, -SentakkiPlayfield.INTERSECTDISTANCE, -SentakkiPlayfield.NOTESTARTDISTANCE);
+        tapHighlight.Y = slideTapHighlight.Y;
+
+        if (Item.TapType is Slide.TapTypeEnum.None)
+        {
+            slideTapHighlight.Alpha = 0.5f;
+            tapHighlight.Alpha = 0;
+        }
+        else if (Item.TapType is Slide.TapTypeEnum.Tap)
+        {
+            slideTapHighlight.Alpha = 0f;
+            tapHighlight.Alpha = 1;
+        }
+        else
+        {
+            SlideTapPiece tapVisual = (SlideTapPiece)DrawableObject.SlideTaps.Child.TapVisual;
+
+            slideTapHighlight.Stars.Rotation = tapVisual.Stars.Rotation;
+            slideTapHighlight.SecondStar.Alpha = tapVisual.SecondStar.Alpha;
+
+            slideTapHighlight.Alpha = 1f;
+            tapHighlight.Alpha = 0;
+        }
 
         if (slideBodyHighlight is null)
             return;

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -286,7 +286,14 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
     private void setExState(SentakkiHitObject hitObject, bool newValue) => hitObject.Ex = newValue;
     private void setBreakState(SentakkiHitObject hitObject, bool newValue) => hitObject.Break = newValue;
 
-    private void setOmitSlideTapState(Slide slide, bool newValue) => slide.TapType = newValue ? Slide.TapTypeEnum.None : Slide.TapTypeEnum.Star;
+    private void setOmitSlideTapState(Slide slide, bool newValue)
+    {
+        slide.TapType = newValue ? Slide.TapTypeEnum.None : Slide.TapTypeEnum.Star;
+
+        // Revalidate the arcs
+        composer.Playfield.Remove(slide);
+        composer.Playfield.Add(slide);
+    }
 
     private void setExSlideState(Slide slide, bool newValue) => slide.SlideInfoList.ForEach(si => si.Ex = newValue);
     private void setBreakSlideState(Slide slide, bool newValue) => slide.SlideInfoList.ForEach(si => si.Break = newValue);

--- a/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/SentakkiSelectionHandler.cs
@@ -32,6 +32,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
 
         exSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setExSlideState, v.NewValue);
         breakSlideTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setBreakSlideState, v.NewValue);
+
+        omitSlideTapTypeTernaryState.ValueChanged += v => applyTernaryChanges<Slide>(setOmitSlideTapState, v.NewValue);
     }
 
     // public override SelectionRotationHandler CreateRotationHandler() => new SentakkiRotationHandler();
@@ -234,6 +236,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
                 new TernaryStateToggleMenuItem("EX") { State = { BindTarget = exSlideTernaryState } }
             ]
         };
+
+        yield return new TernaryStateToggleMenuItem("Omit slide tap") { State = { BindTarget = omitSlideTapTypeTernaryState } };
     }
 
     public readonly Bindable<TernaryState> ExTernaryState = new Bindable<TernaryState>();
@@ -241,6 +245,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
 
     private readonly Bindable<TernaryState> exSlideTernaryState = new Bindable<TernaryState>();
     private readonly Bindable<TernaryState> breakSlideTernaryState = new Bindable<TernaryState>();
+
+    private readonly Bindable<TernaryState> omitSlideTapTypeTernaryState = new Bindable<TernaryState>();
 
     protected override void UpdateTernaryStates()
     {
@@ -250,6 +256,9 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
 
         var selectedSlideBodies = selectedItems.OfType<Slide>().SelectMany(s => s.SlideInfoList);
         breakSlideTernaryState.Value = GetStateFromSelection(selectedSlideBodies, s => s.Break);
+
+        var selectedSlides = selectedItems.OfType<Slide>();
+        omitSlideTapTypeTernaryState.Value = GetStateFromSelection(selectedSlides, s => s.TapType == Slide.TapTypeEnum.None);
     }
 
     private void applyTernaryChanges<T>(Action<T, bool> applicator, TernaryState newTernaryState) where T : HitObject
@@ -276,6 +285,8 @@ public partial class SentakkiSelectionHandler : EditorSelectionHandler
 
     private void setExState(SentakkiHitObject hitObject, bool newValue) => hitObject.Ex = newValue;
     private void setBreakState(SentakkiHitObject hitObject, bool newValue) => hitObject.Break = newValue;
+
+    private void setOmitSlideTapState(Slide slide, bool newValue) => slide.TapType = newValue ? Slide.TapTypeEnum.None : Slide.TapTypeEnum.Star;
 
     private void setExSlideState(Slide slide, bool newValue) => slide.SlideInfoList.ForEach(si => si.Ex = newValue);
     private void setBreakSlideState(Slide slide, bool newValue) => slide.SlideInfoList.ForEach(si => si.Break = newValue);


### PR DESCRIPTION
While not in official non-joke/utage maps, I feel this is a valuable addition to the mapmakers' toolbox when used right.

While I do adjust the selection blueprint to also account for Slides with a regular tap, it is only there for compatibility, and users will not be able to make them in the editor.
<sub>I probably should detach the tap and the slide in that case during import.</sub>

