### PR TITLE
Allow using right click to end placement for holds

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
@@ -101,13 +101,10 @@ public partial class HoldPlacementBlueprint : SentakkiPlacementBlueprint<Hold>
 
     protected override bool OnMouseDown(MouseDownEvent e)
     {
-        if (e.Button is not MouseButton.Left)
-            return base.OnMouseDown(e);
-
         switch (PlacementActive)
         {
             case PlacementState.Waiting:
-                if (!IsValidForPlacement)
+                if (!IsValidForPlacement || e.Button is not MouseButton.Left)
                     break;
 
                 BeginPlacement(IsValidForPlacement);
@@ -115,6 +112,9 @@ public partial class HoldPlacementBlueprint : SentakkiPlacementBlueprint<Hold>
                 return true;
 
             case PlacementState.Active:
+                if (e.Button is not (MouseButton.Left or MouseButton.Right))
+                    break;
+
                 EndPlacement(true);
                 return true;
         }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
@@ -78,25 +78,25 @@ public partial class TouchHoldPlacementBlueprint : SentakkiPlacementBlueprint<To
 
     protected override bool OnMouseDown(MouseDownEvent e)
     {
-        if (e.Button is not MouseButton.Left)
-            return base.OnMouseDown(e);
-
         switch (PlacementActive)
         {
             case PlacementState.Waiting:
-                if (!IsValidForPlacement)
+                if (!IsValidForPlacement || e.Button is not MouseButton.Left)
                     break;
 
-                BeginPlacement(true);
+                BeginPlacement(IsValidForPlacement);
                 commitStartTime = HitObject.StartTime;
-                break;
+                return true;
 
             case PlacementState.Active:
+                if (e.Button is not (MouseButton.Left or MouseButton.Right))
+                    break;
+
                 EndPlacement(true);
-                break;
+                return true;
         }
 
-        return true;
+        return base.OnMouseDown(e);
     }
 
     protected override void OnMouseUp(MouseUpEvent e)


### PR DESCRIPTION
Just so we can match the slides in having right click to end placement.

This is _in addition_ to the existing method of using left click.