### PR TITLE
Fix stateful menu items desync

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
@@ -94,57 +94,69 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
     [Resolved]
     private SentakkiBlueprintContainer blueprintContainer { get; set; } = null!;
 
+    #region Context menu updates
+    private Dictionary<PathShape, TernaryStateRadioMenuItem>? shapeMenuItems;
+    private Dictionary<int, TernaryStateRadioMenuItem>? endLaneMenuItems;
+    private TernaryStateToggleMenuItem? mirrorMenuItem;
+
+    private void updateTernaryItems()
+    {
+        if (shapeMenuItems is null || endLaneMenuItems is null || mirrorMenuItem is null)
+            return;
+
+        foreach (var shape in Enum.GetValues<PathShape>())
+        {
+            var menuItem = shapeMenuItems[shape];
+            menuItem.State.Value = segment.Shape == shape ? TernaryState.True : TernaryState.False;
+        }
+
+        for (int i = 0; i < 8; ++i)
+        {
+            var menuItem = endLaneMenuItems[i];
+
+            menuItem.State.Value = segment.RelativeEndLane == i ? TernaryState.True : TernaryState.False;
+            menuItem.Action.Disabled = !SlidePaths.CheckSlideValidity(segment with { RelativeEndLane = i });
+        }
+
+        mirrorMenuItem.State.Value = segment.Mirrored ? TernaryState.True : TernaryState.False;
+        mirrorMenuItem.Action.Disabled = !SlidePaths.CheckSlideValidity(segment with { Mirrored = true }, true);
+    }
+    #endregion
+
     private IEnumerable<MenuItem> createContextMenuItems()
     {
+        // Add the items present in the SelectionHandler context menu
         foreach (var item in blueprintContainer.SelectionHandler.GetContextMenuItemsForSelection())
             yield return item;
 
         yield return new OsuMenuItemSpacer();
 
-        List<OsuMenuItem> shapeMenuItems = [];
-
-        foreach (var shape in Enum.GetValues<PathShape>())
-        {
-            shapeMenuItems.Add(new OsuMenuItem($"{shape}", MenuItemType.Standard, action: () => changeShape(shape))
-            {
-                Icon = (segment.Shape == shape) ? FontAwesome.Solid.Check : default
-            });
-        }
-
-        yield return new OsuMenuItem("Shape")
-        {
-            Items = shapeMenuItems,
-        };
-
-        List<(int, OsuMenuItem)> endLaneItems = [];
+        shapeMenuItems = Enum.GetValues<PathShape>()
+                       .ToDictionary(p => p, p => new TernaryStateRadioMenuItem($"{p}", action: _ => changeShape(p)));
 
         int currentEndLane = (slide.Lane + slideBodyInfo.Segments.Take(SegmentIndex + 1).Sum(s => s.RelativeEndLane)).NormalizeLane();
         int startLane = (currentEndLane - segment.RelativeEndLane).NormalizeLane();
 
-        foreach (int i in Enumerable.Range(0, 8))
-        {
-            if (!SlidePaths.CheckSlideValidity(segment with { RelativeEndLane = i }))
-                continue;
+        endLaneMenuItems = Enumerable.Range(0, 8)
+                                       .ToDictionary(
+                                            i => i,
+                                            i => new TernaryStateRadioMenuItem($"{(i + startLane).NormalizeLane() + 1}", action: _ => changeEndLane(i)));
 
-            int displayIndex = (i + startLane).NormalizeLane() + 1;
-            endLaneItems.Add((displayIndex, new OsuMenuItem($"{displayIndex}", MenuItemType.Standard, action: () => changeEndLane(i))
-            {
-                Icon = (segment.RelativeEndLane == i) ? FontAwesome.Solid.Check : default
-            }));
-        }
+        yield return new OsuMenuItem("Shape")
+        {
+            Items = [.. shapeMenuItems.Values],
+        };
 
         yield return new OsuMenuItem("End Lane")
         {
-            Items = [.. endLaneItems.OrderBy(i => i.Item1).Select(i => i.Item2)]
+            Items = endLaneMenuItems.OrderBy(kvp => (kvp.Key + startLane).NormalizeLane() + 1)
+                                    .Select(kvp => kvp.Value)
+                                    .ToList()
         };
 
-        if (SlidePaths.CheckSlideValidity(segment with { Mirrored = !segment.Mirrored }, true))
-        {
-            yield return new OsuMenuItem("Mirrored", MenuItemType.Standard, action: () => mirrorSegment())
-            {
-                Icon = (segment.Mirrored == segment.Mirrored) ? FontAwesome.Solid.Check : default
-            };
-        }
+        mirrorMenuItem = new TernaryStateToggleMenuItem("Mirrored", MenuItemType.Standard, action: _ => mirrorSegment());
+
+        yield return mirrorMenuItem;
 
         yield return new OsuMenuItem("Duplicate segment", MenuItemType.Standard, action: duplicateSegment);
 
@@ -154,6 +166,9 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
         yield return new OsuMenuItemSpacer();
 
         yield return new OsuMenuItem("Delete slide", MenuItemType.Destructive, deleteSlide);
+
+        // Let's ensure the initial state is correct
+        updateTernaryItems();
     }
 
     public MenuItem[]? ContextMenuItems => [.. createContextMenuItems()];
@@ -220,6 +235,8 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
 
         slideBodyInfo.Segments = segments;
         beatmap.Update(slide);
+
+        updateTernaryItems();
     }
 
     private void changeEndLane(int lane)
@@ -238,6 +255,8 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
 
         slideBodyInfo.Segments = segments;
         beatmap.Update(slide);
+
+        updateTernaryItems();
     }
 
     protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.Objects;
@@ -43,6 +44,11 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
     [Resolved]
     private SlideTapPiece slideTapPiece { get; set; } = null!;
 
+    [Resolved]
+    private OsuContextMenuContainer? contextMenuContainer { get; set; }
+
+    private Bindable<int> slideLaneBindable;
+
     public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
     {
         if (IsDragged)
@@ -58,6 +64,11 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
     public SlideSegmentHighlight(Slide slide, int segmentIndex)
     {
         this.slide = slide;
+        slideLaneBindable = slide.LaneBindable.GetBoundCopy();
+
+        // When the start lane changes, we forcefully close the context menu to avoid the endLane dropdown making no
+        slideLaneBindable.BindValueChanged(_ => contextMenuContainer?.CloseMenu());
+
         SegmentIndex = segmentIndex;
 
         InternalChildren = [

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
@@ -95,27 +95,26 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
     private SentakkiBlueprintContainer blueprintContainer { get; set; } = null!;
 
     #region Context menu updates
-    private Dictionary<PathShape, TernaryStateRadioMenuItem>? shapeMenuItems;
-    private Dictionary<int, TernaryStateRadioMenuItem>? endLaneMenuItems;
+    private List<(PathShape Shape, TernaryStateRadioMenuItem MenuItem)>? shapeMenuItems;
+    private (int RelativeEndLane, TernaryStateRadioMenuItem MenuItem)[]? endLaneMenuItems;
     private TernaryStateToggleMenuItem? mirrorMenuItem;
 
-    private void updateTernaryItems()
+    private void updateContextMenuItems()
     {
-        if (shapeMenuItems is null || endLaneMenuItems is null || mirrorMenuItem is null)
+        if (shapeMenuItems is null)
             return;
 
-        foreach (var shape in Enum.GetValues<PathShape>())
-        {
-            var menuItem = shapeMenuItems[shape];
+        // If shapeMenuItems is not null, we know these are not null as well
+        Debug.Assert(endLaneMenuItems is not null);
+        Debug.Assert(mirrorMenuItem is not null);
+
+        foreach (var (shape, menuItem) in shapeMenuItems)
             menuItem.State.Value = segment.Shape == shape ? TernaryState.True : TernaryState.False;
-        }
 
-        for (int i = 0; i < 8; ++i)
+        foreach (var (endLane, menuItem) in endLaneMenuItems)
         {
-            var menuItem = endLaneMenuItems[i];
-
-            menuItem.State.Value = segment.RelativeEndLane == i ? TernaryState.True : TernaryState.False;
-            menuItem.Action.Disabled = !SlidePaths.CheckSlideValidity(segment with { RelativeEndLane = i });
+            menuItem.State.Value = segment.RelativeEndLane == endLane ? TernaryState.True : TernaryState.False;
+            menuItem.Action.Disabled = !SlidePaths.CheckSlideValidity(segment with { RelativeEndLane = endLane });
         }
 
         mirrorMenuItem.State.Value = segment.Mirrored ? TernaryState.True : TernaryState.False;
@@ -130,26 +129,22 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
 
         yield return new OsuMenuItemSpacer();
 
-        shapeMenuItems = Enum.GetValues<PathShape>()
-                       .ToDictionary(p => p, p => new TernaryStateRadioMenuItem($"{p}", action: _ => changeShape(p)));
+        shapeMenuItems = [.. Enum.GetValues<PathShape>().Select(s => (s, new TernaryStateRadioMenuItem($"{s}", action: _ => changeShape(s))))];
 
         int currentEndLane = (slide.Lane + slideBodyInfo.Segments.Take(SegmentIndex + 1).Sum(s => s.RelativeEndLane)).NormalizeLane();
         int startLane = (currentEndLane - segment.RelativeEndLane).NormalizeLane();
 
-        endLaneMenuItems = Enumerable.Range(0, 8)
-                                       .ToDictionary(
-                                            i => i,
-                                            i => new TernaryStateRadioMenuItem($"{(i + startLane).NormalizeLane() + 1}", action: _ => changeEndLane(i)));
+        endLaneMenuItems = [.. Enumerable.Range(0, 8).Select(i => (i, new TernaryStateRadioMenuItem($"{(i + startLane).NormalizeLane() + 1}", action: _ => changeEndLane(i))))];
 
         yield return new OsuMenuItem("Shape")
         {
-            Items = [.. shapeMenuItems.Values],
+            Items = [.. shapeMenuItems.Select(kvp => kvp.MenuItem)],
         };
 
         yield return new OsuMenuItem("End Lane")
         {
-            Items = endLaneMenuItems.OrderBy(kvp => (kvp.Key + startLane).NormalizeLane() + 1)
-                                    .Select(kvp => kvp.Value)
+            Items = endLaneMenuItems.OrderBy(kvp => (kvp.RelativeEndLane + startLane).NormalizeLane())
+                                    .Select(kvp => kvp.MenuItem)
                                     .ToList()
         };
 
@@ -167,7 +162,7 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
         yield return new OsuMenuItem("Delete slide", MenuItemType.Destructive, deleteSlide);
 
         // Let's ensure the initial state is correct
-        updateTernaryItems();
+        updateContextMenuItems();
     }
 
     public MenuItem[]? ContextMenuItems => [.. createContextMenuItems()];
@@ -235,7 +230,7 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
         slideBodyInfo.Segments = segments;
         beatmap.Update(slide);
 
-        updateTernaryItems();
+        updateContextMenuItems();
     }
 
     private void changeEndLane(int lane)
@@ -255,7 +250,7 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
         slideBodyInfo.Segments = segments;
         beatmap.Update(slide);
 
-        updateTernaryItems();
+        updateContextMenuItems();
     }
 
     protected override bool OnMouseDown(MouseDownEvent e)

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics.UserInterface;
@@ -100,13 +101,13 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
 
         yield return new OsuMenuItemSpacer();
 
-        List<TernaryStateRadioMenuItem> shapeMenuItems = [];
+        List<OsuMenuItem> shapeMenuItems = [];
 
         foreach (var shape in Enum.GetValues<PathShape>())
         {
-            shapeMenuItems.Add(new TernaryStateRadioMenuItem($"{shape}", action: _ => changeShape(shape))
+            shapeMenuItems.Add(new OsuMenuItem($"{shape}", MenuItemType.Standard, action: () => changeShape(shape))
             {
-                State = { Value = segment.Shape == shape ? TernaryState.True : TernaryState.False }
+                Icon = (segment.Shape == shape) ? FontAwesome.Solid.Check : default
             });
         }
 
@@ -115,7 +116,7 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
             Items = shapeMenuItems,
         };
 
-        List<(int, TernaryStateRadioMenuItem)> endLaneItems = [];
+        List<(int, OsuMenuItem)> endLaneItems = [];
 
         int currentEndLane = (slide.Lane + slideBodyInfo.Segments.Take(SegmentIndex + 1).Sum(s => s.RelativeEndLane)).NormalizeLane();
         int startLane = (currentEndLane - segment.RelativeEndLane).NormalizeLane();
@@ -126,9 +127,9 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
                 continue;
 
             int displayIndex = (i + startLane).NormalizeLane() + 1;
-            endLaneItems.Add((displayIndex, new TernaryStateRadioMenuItem($"{displayIndex}", action: _ => changeEndLane(i))
+            endLaneItems.Add((displayIndex, new OsuMenuItem($"{displayIndex}", MenuItemType.Standard, action: () => changeEndLane(i))
             {
-                State = { Value = segment.RelativeEndLane == i ? TernaryState.True : TernaryState.False }
+                Icon = (segment.RelativeEndLane == i) ? FontAwesome.Solid.Check : default
             }));
         }
 
@@ -139,9 +140,9 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
 
         if (SlidePaths.CheckSlideValidity(segment with { Mirrored = !segment.Mirrored }, true))
         {
-            yield return new TernaryStateToggleMenuItem("Mirrored", action: _ => mirrorSegment())
+            yield return new OsuMenuItem("Mirrored", MenuItemType.Standard, action: () => mirrorSegment())
             {
-                State = { Value = segment.Mirrored ? TernaryState.True : TernaryState.False }
+                Icon = (segment.Mirrored == segment.Mirrored) ? FontAwesome.Solid.Check : default
             };
         }
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlideSegmentHighlight.cs
@@ -119,7 +119,6 @@ public partial class SlideSegmentHighlight : CompositeDrawable, IHasContextMenu
         }
 
         mirrorMenuItem.State.Value = segment.Mirrored ? TernaryState.True : TernaryState.False;
-        mirrorMenuItem.Action.Disabled = !SlidePaths.CheckSlideValidity(segment with { Mirrored = true }, true);
     }
     #endregion
 


### PR DESCRIPTION
Fixes #859.

I've considered using regular `OsuMenuItem`s so that the context menu closes on every interaction, but I agree that keeping the menu open is a better UX, especially when trying out multiple different shapes/end lanes in quick succession.

Relevant ternary items are now tracked, with their actions also triggering an update to the ternary items.
