### PR TITLE
Editor replacement rules

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Holds/HoldPlacementBlueprint.cs
@@ -17,7 +17,7 @@ using osuTK.Input;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Holds;
 
-public partial class HoldPlacementBlueprint : SentakkiPlacementBlueprint<Hold>
+public partial class HoldPlacementBlueprint : LanedPlacementBlueprint<Hold>
 {
     [Resolved]
     private LaneNoteSnapGrid snapGrid { get; set; } = null!;

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/LanedPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/LanedPlacementBlueprint.cs
@@ -1,0 +1,14 @@
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osu.Game.Rulesets.Sentakki.Objects.Types;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints;
+
+public abstract partial class LanedPlacementBlueprint<T> : SentakkiPlacementBlueprint<T>
+    where T : SentakkiHitObject, IHasLane, new()
+{
+    public override bool ReplacesExistingObject(HitObject existing)
+        => base.ReplacesExistingObject(existing)
+            && (existing is IHasLane lanedNote)
+            && lanedNote.Lane == HitObject.Lane;
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/SentakkiPlacementBlueprint.cs
@@ -6,7 +6,7 @@ using osu.Game.Rulesets.Sentakki.Objects;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints;
 
-public partial class SentakkiPlacementBlueprint<T> : HitObjectPlacementBlueprint where T : SentakkiHitObject, new()
+public abstract partial class SentakkiPlacementBlueprint<T> : HitObjectPlacementBlueprint where T : SentakkiHitObject, new()
 {
     public new T HitObject => (T)base.HitObject;
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
@@ -23,7 +23,8 @@ namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
 
 public partial class SlidePlacementBlueprint : LanedPlacementBlueprint<Slide>
 {
-    public override bool ReplacesExistingObject(HitObject existing) => false;
+    public override bool ReplacesExistingObject(HitObject existing)
+        => base.ReplacesExistingObject(existing) && existing is not Slide;
 
     [Resolved]
     private LaneNoteSnapGrid snapGrid { get; set; } = null!;

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Slides/SlidePlacementBlueprint.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Edit;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Sentakki.Edit.Snapping;
 using osu.Game.Rulesets.Sentakki.Extensions;
 using osu.Game.Rulesets.Sentakki.Objects;
@@ -20,8 +21,10 @@ using osuTK.Input;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Slides;
 
-public partial class SlidePlacementBlueprint : SentakkiPlacementBlueprint<Slide>
+public partial class SlidePlacementBlueprint : LanedPlacementBlueprint<Slide>
 {
+    public override bool ReplacesExistingObject(HitObject existing) => false;
+
     [Resolved]
     private LaneNoteSnapGrid snapGrid { get; set; } = null!;
 

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Taps/TapPlacementBlueprint.cs
@@ -17,7 +17,7 @@ using osuTK.Input;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Taps;
 
-public partial class TapPlacementBlueprint : SentakkiPlacementBlueprint<Tap>
+public partial class TapPlacementBlueprint : LanedPlacementBlueprint<Tap>
 {
     [Resolved]
     private LaneNoteSnapGrid snapGrid { get; set; } = null!;

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchHolds/TouchHoldPlacementBlueprint.cs
@@ -14,7 +14,7 @@ using osuTK.Input;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.TouchHolds;
 
-public partial class TouchHoldPlacementBlueprint : SentakkiPlacementBlueprint<TouchHold>
+public partial class TouchHoldPlacementBlueprint : TouchPlacementBlueprint<TouchHold>
 {
     [Cached]
     private IBindable<IReadOnlyList<Color4>>? paletteBindable { get; set; }

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/TouchPlacementBlueprint.cs
@@ -1,0 +1,40 @@
+using System;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Sentakki.Beatmaps;
+using osu.Game.Rulesets.Sentakki.Objects;
+using osuTK;
+
+namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints;
+
+public abstract partial class TouchPlacementBlueprint<T> : SentakkiPlacementBlueprint<T>
+    where T : SentakkiHitObject, IHasPosition, new()
+{
+    private static readonly Lazy<float> minimum_touch_spacing = new Lazy<float>(getMinimumDistance);
+    protected static float MinimumTouchSpacing => minimum_touch_spacing.Value;
+
+    public override bool ReplacesExistingObject(HitObject existing)
+        => base.ReplacesExistingObject(existing)
+            && existing is IHasPosition touchNote
+            && Vector2.Distance(HitObject.Position, touchNote.Position) < MinimumTouchSpacing;
+
+    private static float getMinimumDistance()
+    {
+        var valid_positions = SentakkiBeatmapConverterOld.VALID_TOUCH_POSITIONS;
+        int n = valid_positions.Count;
+
+        float min_distance = float.MaxValue;
+        for (int i = 0; i < n - 1; ++i)
+        {
+            var pos = valid_positions[i];
+            for (int j = i + 1; j < n; ++j)
+            {
+                var pos2 = valid_positions[j];
+
+                min_distance = Math.Min(min_distance, Vector2.Distance(pos, pos2));
+            }
+        }
+
+        return min_distance;
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Sentakki/Edit/Blueprints/Touches/TouchPlacementBlueprint.cs
@@ -1,7 +1,6 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Sentakki.Edit.Snapping;
@@ -13,7 +12,7 @@ using osuTK.Input;
 
 namespace osu.Game.Rulesets.Sentakki.Edit.Blueprints.Touches;
 
-public partial class TouchPlacementBlueprint : SentakkiPlacementBlueprint<Touch>
+public partial class TouchPlacementBlueprint : TouchPlacementBlueprint<Touch>
 {
     private readonly TouchBody highlight;
 


### PR DESCRIPTION
Tap and Holds will unconditionally replace any laned notes it overlaps
with
Slides will replace Taps and Holds, but not slides. (since stacked slides are meant to be multislides)

Touches and TouchHolds will replace any touch notes that are do close.