### PR TITLE
Modify the difficulty multiplier from 1.25x to 0.75x for sen to better match expected SR value

### DIFF
--- a/osu.Game.Rulesets.Sentakki/Difficulty/SentakkiDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Sentakki/Difficulty/SentakkiDifficultyCalculator.cs
@@ -12,7 +12,7 @@ public class SentakkiDifficultyCalculator(IRulesetInfo ruleset, IWorkingBeatmap 
     protected override DifficultyAttributes CreateDifficultyAttributes(IBeatmap beatmap, Mod[] mods, Skill[] skills)
         => new DifficultyAttributes
         {
-            StarRating = beatmap.BeatmapInfo.StarRating * 1.25f, // Inflate SR of converts, to encourage players to try lower diffs, without hurting their fragile ego.
+            StarRating = beatmap.BeatmapInfo.StarRating * 0.75f,
             Mods = mods,
             MaxCombo = beatmap.GetMaxCombo()
         };


### PR DESCRIPTION
Until sen gets an actual SR calc (which could take years), I think that this value should be changed to something better. Currently, the value is very inflated and makes no real sense when compared with any other ruleset (despite the fact that this ruleset has many similarities with std and skill transfers relatively easily).
To get to the 0.75x value, I have referenced [this spreadsheet](https://github.com/user-attachments/files/30064390/sen.SR.xlsx), where I set 24 plays on std and stki.
Sorry egos.

Related: https://github.com/LumpBloom7/sentakki/issues/188, https://github.com/LumpBloom7/sentakki/pull/701