### PR TITLE
Implement common classes that will be used for skinning

### DIFF
--- a/osu.Game.Rulesets.Sentakki.Tests/Resources/special-skin/skin.ini
+++ b/osu.Game.Rulesets.Sentakki.Tests/Resources/special-skin/skin.ini
@@ -1,0 +1,4 @@
+[General]
+Name: SentakkiTest
+Author: Bloom
+Version: 2.7

--- a/osu.Game.Rulesets.Sentakki.Tests/SentakkiSkinnableTestScene.cs
+++ b/osu.Game.Rulesets.Sentakki.Tests/SentakkiSkinnableTestScene.cs
@@ -1,0 +1,23 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Sentakki.Tests;
+
+public abstract partial class SentakkiSkinnableTestScene : SkinnableTestScene
+{
+    private Container content = null!;
+
+    protected override Container<Drawable> Content
+    {
+        get
+        {
+            if (content == null)
+                base.Content.Add(content = new SentakkiInputManager(new SentakkiRuleset().RulesetInfo));
+
+            return content;
+        }
+    }
+
+    protected override Ruleset CreateRulesetForSkinProvider() => new SentakkiRuleset();
+}

--- a/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
+++ b/osu.Game.Rulesets.Sentakki/SentakkiRuleset.cs
@@ -32,12 +32,14 @@ using osu.Game.Rulesets.Sentakki.Mods;
 using osu.Game.Rulesets.Sentakki.Objects;
 using osu.Game.Rulesets.Sentakki.Replays;
 using osu.Game.Rulesets.Sentakki.Scoring;
+using osu.Game.Rulesets.Sentakki.Skinning.Legacy;
 using osu.Game.Rulesets.Sentakki.Statistics;
 using osu.Game.Rulesets.Sentakki.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
+using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
 
@@ -216,6 +218,15 @@ public partial class SentakkiRuleset : Ruleset
         => [HitResult.Perfect, HitResult.Great, HitResult.Good, HitResult.Meh, HitResult.Miss];
 
     public override LocalisableString GetDisplayNameForHitResult(HitResult result) => result.GetDisplayNameForSentakkiResult();
+
+    public override ISkin? CreateSkinTransformer(ISkin skin, IBeatmap beatmap)
+    {
+        return skin switch
+        {
+            LegacySkin => new SentakkiLegacySkinTransformer(skin),
+            _ => null
+        };
+    }
 
     public partial class SentakkiIcon : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Sentakki/Skinning/Legacy/SentakkiLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Sentakki/Skinning/Legacy/SentakkiLegacySkinTransformer.cs
@@ -1,0 +1,25 @@
+using osu.Framework.Graphics;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Sentakki.Skinning.Legacy;
+
+public class SentakkiLegacySkinTransformer(ISkin skin) : LegacySkinTransformer(skin)
+{
+    public override Drawable? GetDrawableComponent(ISkinComponentLookup lookup)
+    {
+        switch (lookup)
+        {
+            case SentakkiSkinComponentLookup sentakkiComponent:
+
+                switch (sentakkiComponent)
+                {
+                    default:
+                        break;
+                }
+
+                break;
+        }
+
+        return base.GetDrawableComponent(lookup);
+    }
+}

--- a/osu.Game.Rulesets.Sentakki/Skinning/Legacy/SentakkiLegacySkinTransformer.cs
+++ b/osu.Game.Rulesets.Sentakki/Skinning/Legacy/SentakkiLegacySkinTransformer.cs
@@ -10,8 +10,7 @@ public class SentakkiLegacySkinTransformer(ISkin skin) : LegacySkinTransformer(s
         switch (lookup)
         {
             case SentakkiSkinComponentLookup sentakkiComponent:
-
-                switch (sentakkiComponent)
+                switch (sentakkiComponent.Component)
                 {
                     default:
                         break;

--- a/osu.Game.Rulesets.Sentakki/Skinning/ProxyableSkinnableDrawable.cs
+++ b/osu.Game.Rulesets.Sentakki/Skinning/ProxyableSkinnableDrawable.cs
@@ -1,0 +1,11 @@
+using System;
+using osu.Framework.Graphics;
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Sentakki.Skinning;
+
+public partial class ProxyableSkinnableDrawable(ISkinComponentLookup lookup, Func<ISkinComponentLookup, Drawable>? defaultImplementation = null, ConfineMode confineMode = ConfineMode.NoScaling)
+    : SkinnableDrawable(lookup, defaultImplementation, confineMode)
+{
+    public override bool RemoveWhenNotAlive => false;
+}

--- a/osu.Game.Rulesets.Sentakki/Skinning/SentakkiSkinComponentLookup.cs
+++ b/osu.Game.Rulesets.Sentakki/Skinning/SentakkiSkinComponentLookup.cs
@@ -1,0 +1,6 @@
+using osu.Game.Skinning;
+
+namespace osu.Game.Rulesets.Sentakki.Skinning;
+
+public class SentakkiSkinComponentLookup(SentakkiSkinComponents component)
+    : SkinComponentLookup<SentakkiSkinComponents>(component);

--- a/osu.Game.Rulesets.Sentakki/Skinning/SentakkiSkinComponents.cs
+++ b/osu.Game.Rulesets.Sentakki/Skinning/SentakkiSkinComponents.cs
@@ -1,0 +1,6 @@
+namespace osu.Game.Rulesets.Sentakki.Skinning;
+
+public enum SentakkiSkinComponents
+{
+
+}


### PR DESCRIPTION
I want to split #897 into smaller parts, and this serves as a common shared base to be used among all of them.